### PR TITLE
fix(providers): correctly return mapped rpc requests

### DIFF
--- a/ethers-providers/src/main/kotlin/io/ethers/providers/types/BatchRpcRequest.kt
+++ b/ethers-providers/src/main/kotlin/io/ethers/providers/types/BatchRpcRequest.kt
@@ -12,10 +12,10 @@ class BatchRpcRequest @JvmOverloads constructor(defaultSize: Int = 10) {
     private val batchSent = AtomicBoolean(false)
 
     private val _requests = ArrayList<RpcCall<*>>(defaultSize)
-    val requests: List<RpcCall<*>> get() = _requests
+    internal val requests: List<RpcCall<*>> get() = _requests
 
     private val _responses = ArrayList<CompletableFuture<RpcResponse<*>>>(defaultSize)
-    val responses: List<CompletableFuture<RpcResponse<*>>> get() = _responses
+    internal val responses: List<CompletableFuture<RpcResponse<*>>> get() = _responses
 
     private var client: JsonRpcClient? = null
 
@@ -131,14 +131,15 @@ fun <T> Iterable<RpcRequest<out T>>.sendAsync(): BatchResponseAsync<T> {
         return BatchResponseAsync(emptyList())
     }
 
+    val futures = ArrayList<CompletableFuture<RpcResponse<T>>>()
     val batch = BatchRpcRequest()
     while (iter.hasNext()) {
-        iter.next().batch(batch)
+        futures.add(iter.next().batch(batch) as CompletableFuture<RpcResponse<T>>)
     }
 
     batch.sendAsync()
 
-    return BatchResponseAsync(batch.responses as List<CompletableFuture<RpcResponse<T>>>)
+    return BatchResponseAsync(futures)
 }
 
 // Zero-cost typed response classes to provide specialized "component" operators. In case it's used as a different type


### PR DESCRIPTION
<!--
THANK YOU for your Pull Request. Please provide additional information about proposed 
changes below.

Code changes (e.g. bug fixes and new features) should include:
- tests
- documentation

Contributors guide: https://github.com/Kr1ptal/ethers-kt/blob/master/CONTRIBUTING.md
-->

## Description
We returned the unmapped `RpcResult` when batch-calling list of `MappedRpcRequest` instead of the mapped version.

<!--
Please provide the context and rationale for your proposed changes. 

What is the specific issue you intend to address? In some cases, no issue exists, and you should provide
the motivation for making this change.
-->

## Solution
Return the mapped rpc response.

<!--
Please provide a concise summary of the solution and offer the context required for 
understanding the code changes.

If you have any pseudocode, sketches, snapshots, links or other resources explaining
the solution, please include those as well.
-->
