### PR TITLE
fix(providers): create `eth_call` params array with minimal amount of values

### DIFF
--- a/ethers-providers/src/main/kotlin/io/ethers/providers/Provider.kt
+++ b/ethers-providers/src/main/kotlin/io/ethers/providers/Provider.kt
@@ -132,7 +132,13 @@ class Provider(override val client: JsonRpcClient) : Middleware {
         stateOverride: Map<Address, AccountOverride>?,
         blockOverride: BlockOverride?,
     ): RpcRequest<Bytes> {
-        val params = arrayOf(call, blockId.id, stateOverride, blockOverride)
+        // create minimal params array - some RPC's don't support stateOverride or blockOverride
+        val params = when {
+            blockOverride != null -> arrayOf(call, blockId.id, stateOverride, blockOverride)
+            stateOverride != null -> arrayOf(call, blockId.id, stateOverride)
+            else -> arrayOf(call, blockId.id)
+        }
+
         return RpcCall(client, "eth_call", params, Bytes::class.java)
     }
 


### PR DESCRIPTION
<!--
THANK YOU for your Pull Request. Please provide additional information about proposed 
changes below.

Code changes (e.g. bug fixes and new features) should include:
- tests
- documentation

Contributors guide: https://github.com/Kr1ptal/ethers-kt/blob/master/CONTRIBUTING.md
-->

## Description
Some RPC's don't support setting block overrides, so always use the minimal amount of params to make it work for cases where we don't need to set any overrides for block.

<!--
Please provide the context and rationale for your proposed changes. 

What is the specific issue you intend to address? In some cases, no issue exists, and you should provide
the motivation for making this change.
-->

## Solution

<!--
Please provide a concise summary of the solution and offer the context required for 
understanding the code changes.

If you have any pseudocode, sketches, snapshots, links or other resources explaining
the solution, please include those as well.
-->
