### PR TITLE
fix(abigen): add resolver error factories in generated wrappers via companion object init

### DIFF
--- a/ethers-abigen/src/test/kotlin/io/ethers/abigen/cases/OffchainResolverTest.kt
+++ b/ethers-abigen/src/test/kotlin/io/ethers/abigen/cases/OffchainResolverTest.kt
@@ -1,0 +1,75 @@
+package io.ethers.abigen.cases
+
+import io.ethers.abi.AbiFunction
+import io.ethers.abi.AbiType
+import io.ethers.abi.call.ReadFunctionCall
+import io.ethers.abigen.AbigenCompiler
+import io.ethers.abigen.ArgDescriptor
+import io.ethers.abigen.ClassDescriptor
+import io.ethers.abigen.FunctionDescriptor
+import io.ethers.abigen.getAbiFunctionField
+import io.ethers.abigen.getDeclaredErrors
+import io.ethers.abigen.getDeclaredFunctions
+import io.ethers.abigen.getDeclaredStructs
+import io.ethers.abigen.parametrizedBy
+import io.ethers.core.types.Address
+import io.ethers.core.types.Bytes
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
+
+class OffchainResolverTest : FunSpec({
+    context("abigen validation") {
+        val clazz = AbigenCompiler.compile("/abi/OffchainResolver.json")
+
+        test("class name") {
+            clazz.simpleName shouldBe "OffchainResolver"
+        }
+
+        test("functions") {
+            clazz.getDeclaredFunctions() shouldContainAll listOf(
+                FunctionDescriptor(
+                    "resolve",
+                    listOf(
+                        ArgDescriptor("name", Bytes::class),
+                        ArgDescriptor("data", Bytes::class),
+                    ),
+                    ReadFunctionCall::class.parametrizedBy(Bytes::class),
+                ),
+            )
+        }
+
+        test("structs") {
+            clazz.getDeclaredStructs().classes.size shouldBe 0
+        }
+
+        test("errors") {
+            val errors = clazz.getDeclaredErrors()
+            errors.classes.size shouldBe 1
+
+            errors.descriptors shouldContainAll listOf(
+                ClassDescriptor(
+                    "OffchainLookup",
+                    listOf(
+                        ArgDescriptor("sender", Address::class),
+                        ArgDescriptor("urls", Array::class.parametrizedBy(String::class)),
+                        ArgDescriptor("callData", Bytes::class),
+                        ArgDescriptor("callbackFunction", Bytes::class),
+                        ArgDescriptor("extraData", Bytes::class),
+                    ),
+                ),
+            )
+        }
+
+        test("AbiFunction field") {
+            clazz.getAbiFunctionField("FUNCTION_RESOLVE") shouldBe AbiFunction(
+                name = "resolve",
+                inputs = listOf(
+                    AbiType.Bytes,
+                    AbiType.Bytes,
+                ),
+                outputs = listOf(AbiType.Bytes),
+            )
+        }
+    }
+})

--- a/ethers-abigen/src/test/resources/abi/OffchainResolver.json
+++ b/ethers-abigen/src/test/resources/abi/OffchainResolver.json
@@ -1,0 +1,195 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_url",
+        "type": "string"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_signers",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "string[]",
+        "name": "urls",
+        "type": "string[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "callData",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes4",
+        "name": "callbackFunction",
+        "type": "bytes4"
+      },
+      {
+        "internalType": "bytes",
+        "name": "extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "OffchainLookup",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address[]",
+        "name": "signers",
+        "type": "address[]"
+      }
+    ],
+    "name": "NewSigners",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      },
+      {
+        "internalType": "uint64",
+        "name": "expires",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bytes",
+        "name": "request",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "result",
+        "type": "bytes"
+      }
+    ],
+    "name": "makeSignatureHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "name",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "resolve",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "response",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "resolveWithProof",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "signers",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceID",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "url",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
<!--
THANK YOU for your Pull Request. Please provide additional information about proposed 
changes below.

Code changes (e.g. bug fixes and new features) should include:
- tests
- documentation

Contributors guide: https://github.com/Kr1ptal/ethers-kt/blob/master/CONTRIBUTING.md
-->

## Description

If contract abi has only one custom error, the generated code would produce compilation error.

<!--
Please provide the context and rationale for your proposed changes. 

What is the specific issue you intend to address? In some cases, no issue exists, and you should provide
the motivation for making this change.
-->

## Solution

Moved registration of generated errors to companion object "init" block.

closes #40

<!--
Please provide a concise summary of the solution and offer the context required for 
understanding the code changes.

If you have any pseudocode, sketches, snapshots, links or other resources explaining
the solution, please include those as well.
-->
