### PR TITLE
feat(providers): improve functional operators on `RpcRequest`/`RpcResponse`

### DIFF
--- a/buildSrc/src/main/kotlin/java-toolchain-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-toolchain-conventions.gradle.kts
@@ -8,10 +8,19 @@ project.pluginManager.withPlugin("java") {
         implementation.set(JvmImplementation.VENDOR_SPECIFIC)
     }
 
-    tasks.withType<JavaExec>().configureEach {
+    tasks.withType<JavaExec>().all {
         javaLauncher.set(javaToolchainService.launcherFor(extension.toolchain))
     }
-    tasks.withType<Test>().configureEach {
+
+    tasks.withType<Test>().all {
         javaLauncher.set(javaToolchainService.launcherFor(extension.toolchain))
+    }
+
+    // temp fix: https://youtrack.jetbrains.com/issue/IDEA-316081/Gradle-8-toolchain-error-Toolchain-from-executable-property-does-not-match-toolchain-from-javaLauncher-property-when-different#focus=Comments-27-7276479.0-0
+    gradle.taskGraph.whenReady {
+        tasks.withType<JavaExec>().all {
+            @Suppress("UsePropertyAccessSyntax")
+            setExecutable(javaLauncher.get().executablePath.asFile.absolutePath)
+        }
     }
 }


### PR DESCRIPTION
<!--
THANK YOU for your Pull Request. Please provide additional information about proposed 
changes below.

Code changes (e.g. bug fixes and new features) should include:
- tests
- documentation

Contributors guide: https://github.com/Kr1ptal/ethers-kt/blob/master/CONTRIBUTING.md
-->

## Description

Refactor "map" to operate on and expect a re-mapped result. Added `mapError`, `andThen`, and `orElse` functions.

<!--
Please provide the context and rationale for your proposed changes. 

What is the specific issue you intend to address? In some cases, no issue exists, and you should provide
the motivation for making this change.
-->

## Solution

<!--
Please provide a concise summary of the solution and offer the context required for 
understanding the code changes.

If you have any pseudocode, sketches, snapshots, links or other resources explaining
the solution, please include those as well.
-->
