### PR TITLE
feat(core,providers): add `IntoCallRequest` interface and use it in provider function arguments 

### DIFF
--- a/ethers-abi/src/main/kotlin/io/ethers/abi/call/AggregationResult.kt
+++ b/ethers-abi/src/main/kotlin/io/ethers/abi/call/AggregationResult.kt
@@ -33,4 +33,21 @@ class AggregationResult<T>(private val results: Array<Result<T, ContractError>>)
     @get:JvmSynthetic
     val indices: IntRange
         get() = results.indices
+
+    override fun toString(): String {
+        return "AggregationResult(${results.contentToString()})"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as AggregationResult<*>
+
+        return results.contentEquals(other.results)
+    }
+
+    override fun hashCode(): Int {
+        return results.contentHashCode()
+    }
 }

--- a/ethers-abi/src/main/kotlin/io/ethers/abi/call/ContractCall.kt
+++ b/ethers-abi/src/main/kotlin/io/ethers/abi/call/ContractCall.kt
@@ -15,6 +15,7 @@ import io.ethers.core.types.BlockOverride
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.CallRequest
 import io.ethers.core.types.Hash
+import io.ethers.core.types.IntoCallRequest
 import io.ethers.core.types.tracers.TracerConfig
 import io.ethers.core.types.transaction.TransactionSigned
 import io.ethers.core.types.transaction.TransactionUnsigned
@@ -129,8 +130,27 @@ abstract class ReadWriteContractCall<C, S : PendingInclusion<*>, B : ReadWriteCo
  * */
 abstract class ReadContractCall<C, B : ReadContractCall<C, B>>(
     val provider: Middleware,
-) {
+) : IntoCallRequest {
     protected val call = CallRequest().apply { chainId = provider.chainId }
+
+    override fun toCallRequest(): CallRequest {
+        // create a new instance to avoid modifying the original
+        return CallRequest {
+            from(call.from)
+            to(call.to)
+            gas(call.gas)
+            gasPrice(call.gasPrice)
+            gasFeeCap(call.gasFeeCap)
+            gasTipCap(call.gasTipCap)
+            value(call.value)
+            nonce(call.nonce)
+            data(call.data)
+            accessList(call.accessList)
+            chainId(call.chainId)
+            blobFeeCap(call.blobFeeCap)
+            blobVersionedHashes(call.blobVersionedHashes)
+        }
+    }
 
     /**
      * Execute "eth_call" at the given [blockHash] and return the result of the call. This is a read-only call, and it

--- a/ethers-core/src/main/kotlin/io/ethers/core/types/CallRequest.kt
+++ b/ethers-core/src/main/kotlin/io/ethers/core/types/CallRequest.kt
@@ -8,7 +8,11 @@ import io.ethers.core.FastHex
 import java.math.BigInteger
 
 @JsonSerialize(using = CallRequestSerializer::class)
-class CallRequest {
+class CallRequest : IntoCallRequest {
+    override fun toCallRequest(): CallRequest {
+        return this
+    }
+
     // make property setters unavailable from Java since we provide custom chained functions
     var from: Address? = null
         @JvmSynthetic set
@@ -195,4 +199,14 @@ private class CallRequestSerializer : JsonSerializer<CallRequest>() {
         }
         gen.writeEndObject()
     }
+}
+
+/**
+ * Interface to convert a class into a [CallRequest].
+ * */
+interface IntoCallRequest {
+    /**
+     * Get the [CallRequest] representation of `this` class.
+     * */
+    fun toCallRequest(): CallRequest
 }

--- a/ethers-core/src/main/kotlin/io/ethers/core/types/CallRequest.kt
+++ b/ethers-core/src/main/kotlin/io/ethers/core/types/CallRequest.kt
@@ -55,6 +55,15 @@ class CallRequest {
     var chainId: Long = -1L
         @JvmSynthetic set
 
+    var blobFeeCap: BigInteger? = null
+        @JvmSynthetic set(value) {
+            require(value == null || value >= BigInteger.ZERO) { "BlobFeeCap must be non-negative" }
+            field = value
+        }
+
+    var blobVersionedHashes: List<Hash>? = null
+        @JvmSynthetic set
+
     fun from(from: Address?): CallRequest {
         this.from = from
         return this
@@ -110,8 +119,18 @@ class CallRequest {
         return this
     }
 
+    fun blobFeeCap(blobFeeCap: BigInteger?): CallRequest {
+        this.blobFeeCap = blobFeeCap
+        return this
+    }
+
+    fun blobVersionedHashes(blobVersionedHashes: List<Hash>?): CallRequest {
+        this.blobVersionedHashes = blobVersionedHashes
+        return this
+    }
+
     override fun toString(): String {
-        return "CallRequest(from=$from, to=$to, gas=$gas, gasPrice=$gasPrice, gasFeeCap=$gasFeeCap, gasTipCap=$gasTipCap, value=$value, nonce=$nonce, data=$data, accessList=$accessList, chainId=$chainId)"
+        return "CallRequest(from=$from, to=$to, gas=$gas, gasPrice=$gasPrice, gasFeeCap=$gasFeeCap, gasTipCap=$gasTipCap, value=$value, nonce=$nonce, data=$data, accessList=$accessList, chainId=$chainId, blobFeeCap=$blobFeeCap, blobVersionedHashes=$blobVersionedHashes)"
     }
 
     companion object {
@@ -161,6 +180,18 @@ private class CallRequestSerializer : JsonSerializer<CallRequest>() {
         }
         if (value.chainId != -1L) {
             gen.writeStringField("chainId", FastHex.encodeWithPrefix(value.chainId))
+        }
+        val blobFeeCap = value.blobFeeCap
+        if (blobFeeCap != null) {
+            gen.writeStringField("maxFeePerBlobGas", FastHex.encodeWithPrefix(blobFeeCap))
+        }
+        val blobVersionedHashes = value.blobVersionedHashes
+        if (blobVersionedHashes != null) {
+            gen.writeArrayFieldStart("blobVersionedHashes")
+            for (i in blobVersionedHashes.indices) {
+                gen.writeString(blobVersionedHashes[i].toString())
+            }
+            gen.writeEndArray()
         }
         gen.writeEndObject()
     }

--- a/ethers-core/src/main/kotlin/io/ethers/core/types/transaction/TransactionSigned.kt
+++ b/ethers-core/src/main/kotlin/io/ethers/core/types/transaction/TransactionSigned.kt
@@ -2,6 +2,7 @@ package io.ethers.core.types.transaction
 
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
+import io.ethers.core.types.CallRequest
 import io.ethers.core.types.Hash
 import io.ethers.core.types.Signature
 import io.ethers.crypto.Hashing
@@ -27,6 +28,10 @@ class TransactionSigned @JvmOverloads constructor(
     private var _hash: Hash? = hash
     private var _from: Address? = from
     private var _isValidSignature: Int = -1
+
+    override fun toCallRequest(): CallRequest {
+        return super<TransactionRecovered>.toCallRequest()
+    }
 
     /**
      * Get the transaction hash.
@@ -134,6 +139,11 @@ class TransactionSigned @JvmOverloads constructor(
     }
 
     companion object : RlpDecodable<TransactionSigned> {
+        @JvmStatic
+        override fun rlpDecode(data: ByteArray): TransactionSigned? {
+            return super.rlpDecode(data)
+        }
+
         @JvmStatic
         override fun rlpDecode(rlp: RlpDecoder): TransactionSigned? {
             val type = rlp.peekByte().toUByte().toInt()

--- a/ethers-core/src/test/kotlin/io/ethers/core/types/CallRequestTest.kt
+++ b/ethers-core/src/test/kotlin/io/ethers/core/types/CallRequestTest.kt
@@ -75,5 +75,8 @@ class CallRequestTest : FunSpec({
 
         shouldThrowUnit<IllegalArgumentException> { request.value = BigInteger.ONE.negate() }
         shouldThrowUnit<IllegalArgumentException> { request.value(BigInteger.ONE.negate()) }
+
+        shouldThrowUnit<IllegalArgumentException> { request.blobFeeCap = BigInteger.ONE.negate() }
+        shouldThrowUnit<IllegalArgumentException> { request.blobFeeCap(BigInteger.ONE.negate()) }
     }
 })

--- a/ethers-providers/src/main/kotlin/io/ethers/providers/middleware/DebugApi.kt
+++ b/ethers-providers/src/main/kotlin/io/ethers/providers/middleware/DebugApi.kt
@@ -2,8 +2,8 @@ package io.ethers.providers.middleware
 
 import io.ethers.core.types.BlockId
 import io.ethers.core.types.Bytes
-import io.ethers.core.types.CallRequest
 import io.ethers.core.types.Hash
+import io.ethers.core.types.IntoCallRequest
 import io.ethers.core.types.tracers.TracerConfig
 import io.ethers.core.types.tracers.TxTraceResult
 import io.ethers.providers.RpcError
@@ -69,7 +69,7 @@ interface DebugApi {
     /**
      * Execute [call] on given [blockId] and trace its execution with given tracer [config].
      */
-    fun <T> traceCall(call: CallRequest, blockId: BlockId, config: TracerConfig<T>): RpcRequest<T, RpcError>
+    fun <T> traceCall(call: IntoCallRequest, blockId: BlockId, config: TracerConfig<T>): RpcRequest<T, RpcError>
 
     /**
      * Execute arbitrary number of [calls] starting at an arbitrary [transactionIndex] in the block, and tracing their
@@ -83,7 +83,7 @@ interface DebugApi {
      * */
     fun <T> traceCallMany(
         blockNumber: Long,
-        calls: List<CallRequest>,
+        calls: List<IntoCallRequest>,
         config: TracerConfig<T>,
         transactionIndex: Int = -1,
     ): RpcRequest<List<T>, RpcError> {
@@ -102,7 +102,7 @@ interface DebugApi {
      * */
     fun <T> traceCallMany(
         blockHash: Hash,
-        calls: List<CallRequest>,
+        calls: List<IntoCallRequest>,
         config: TracerConfig<T>,
         transactionIndex: Int = -1,
     ): RpcRequest<List<T>, RpcError> {
@@ -121,7 +121,7 @@ interface DebugApi {
      * */
     fun <T> traceCallMany(
         blockId: BlockId,
-        calls: List<CallRequest>,
+        calls: List<IntoCallRequest>,
         config: TracerConfig<T>,
         transactionIndex: Int = -1,
     ): RpcRequest<List<T>, RpcError>

--- a/ethers-providers/src/main/kotlin/io/ethers/providers/middleware/EthApi.kt
+++ b/ethers-providers/src/main/kotlin/io/ethers/providers/middleware/EthApi.kt
@@ -8,9 +8,9 @@ import io.ethers.core.types.BlockOverride
 import io.ethers.core.types.BlockWithHashes
 import io.ethers.core.types.BlockWithTransactions
 import io.ethers.core.types.Bytes
-import io.ethers.core.types.CallRequest
 import io.ethers.core.types.FeeHistory
 import io.ethers.core.types.Hash
+import io.ethers.core.types.IntoCallRequest
 import io.ethers.core.types.Log
 import io.ethers.core.types.LogFilter
 import io.ethers.core.types.RPCTransaction
@@ -161,25 +161,25 @@ interface EthApi {
     /**
      * Execute [call] on given [blockId].
      */
-    fun call(call: CallRequest, blockId: BlockId) = call(call, blockId, null, null)
+    fun call(call: IntoCallRequest, blockId: BlockId) = call(call, blockId, null, null)
 
     /**
      * Execute [call] on given [blockId] with applied state overrides.
      */
-    fun call(call: CallRequest, blockId: BlockId, stateOverride: Map<Address, AccountOverride>) =
+    fun call(call: IntoCallRequest, blockId: BlockId, stateOverride: Map<Address, AccountOverride>) =
         call(call, blockId, stateOverride, null)
 
     /**
      * Execute [call] on given [blockId] with applied block overrides.
      */
-    fun call(call: CallRequest, blockId: BlockId, blockOverride: BlockOverride) =
+    fun call(call: IntoCallRequest, blockId: BlockId, blockOverride: BlockOverride) =
         call(call, blockId, null, blockOverride)
 
     /**
      * Execute [call] on given [blockId] with applied state and block overrides.
      */
     fun call(
-        call: CallRequest,
+        call: IntoCallRequest,
         blockId: BlockId,
         stateOverride: Map<Address, AccountOverride>? = null,
         blockOverride: BlockOverride? = null,
@@ -198,7 +198,7 @@ interface EthApi {
      * */
     fun callMany(
         blockNumber: Long,
-        calls: List<CallRequest>,
+        calls: List<IntoCallRequest>,
         transactionIndex: Int = -1,
         stateOverride: Map<Address, AccountOverride>? = null,
         blockOverride: BlockOverride? = null,
@@ -219,7 +219,7 @@ interface EthApi {
      * */
     fun callMany(
         blockHash: Hash,
-        calls: List<CallRequest>,
+        calls: List<IntoCallRequest>,
         transactionIndex: Int = -1,
         stateOverride: Map<Address, AccountOverride>? = null,
         blockOverride: BlockOverride? = null,
@@ -240,7 +240,7 @@ interface EthApi {
      * */
     fun callMany(
         blockId: BlockId,
-        calls: List<CallRequest>,
+        calls: List<IntoCallRequest>,
         transactionIndex: Int = -1,
         stateOverride: Map<Address, AccountOverride>? = null,
         blockOverride: BlockOverride? = null,
@@ -249,32 +249,32 @@ interface EthApi {
     /**
      * Estimate gas required to execute [call] on given block [hash].
      */
-    fun estimateGas(call: CallRequest, hash: Hash) = estimateGas(call, BlockId.Hash(hash))
+    fun estimateGas(call: IntoCallRequest, hash: Hash) = estimateGas(call, BlockId.Hash(hash))
 
     /**
      * Estimate gas required to execute [call] on given block [number].
      */
-    fun estimateGas(call: CallRequest, number: Long) = estimateGas(call, BlockId.Number(number))
+    fun estimateGas(call: IntoCallRequest, number: Long) = estimateGas(call, BlockId.Number(number))
 
     /**
      * Estimate gas required to execute [call] on given [blockId].
      */
-    fun estimateGas(call: CallRequest, blockId: BlockId): RpcRequest<BigInteger, RpcError>
+    fun estimateGas(call: IntoCallRequest, blockId: BlockId): RpcRequest<BigInteger, RpcError>
 
     /**
      * Create access list for a given transaction [call] on a given block [hash].
      */
-    fun createAccessList(call: CallRequest, hash: Hash) = createAccessList(call, BlockId.Hash(hash))
+    fun createAccessList(call: IntoCallRequest, hash: Hash) = createAccessList(call, BlockId.Hash(hash))
 
     /**
      * Create access list for a given transaction [call] on a given block [number].
      */
-    fun createAccessList(call: CallRequest, number: Long) = createAccessList(call, BlockId.Number(number))
+    fun createAccessList(call: IntoCallRequest, number: Long) = createAccessList(call, BlockId.Number(number))
 
     /**
      * Create access list for a given transaction [call] on a given block [blockId].
      */
-    fun createAccessList(call: CallRequest, blockId: BlockId): RpcRequest<*, RpcError>
+    fun createAccessList(call: IntoCallRequest, blockId: BlockId): RpcRequest<*, RpcError>
 
     /**
      * Get gas price suggestion for legacy transaction.
@@ -401,7 +401,7 @@ interface EthApi {
      * Fill the defaults (nonce, gas, gasPrice or 1559 fields) and return unsigned transaction for further
      * processing (signing + submission).
      */
-    fun fillTransaction(call: CallRequest): RpcRequest<TransactionUnsigned, RpcError>
+    fun fillTransaction(call: IntoCallRequest): RpcRequest<TransactionUnsigned, RpcError>
 
     /**
      * Get logs by block [blockHash].

--- a/ethers-providers/src/main/kotlin/io/ethers/providers/types/CallManyTypes.kt
+++ b/ethers-providers/src/main/kotlin/io/ethers/providers/types/CallManyTypes.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import io.ethers.core.Result
 import io.ethers.core.types.BlockId
 import io.ethers.core.types.BlockOverride
-import io.ethers.core.types.CallRequest
+import io.ethers.core.types.IntoCallRequest
 
 /**
  * Error returned for a call in `eth_callMany` that fails.
@@ -19,7 +19,7 @@ data class CallFailedError(val error: String) : Result.Error
  * */
 @JsonSerialize(using = CallManyBundleSerializer::class)
 internal data class CallManyBundle(
-    val transactions: List<CallRequest>,
+    val transactions: List<IntoCallRequest>,
     val blockOverride: BlockOverride? = null,
 )
 
@@ -39,7 +39,7 @@ private class CallManyBundleSerializer : JsonSerializer<CallManyBundle>() {
         gen.writeArrayFieldStart("transactions")
         for (i in value.transactions.indices) {
             // delegate to CallRequest serializer
-            gen.writeObject(value.transactions[i])
+            gen.writeObject(value.transactions[i].toCallRequest())
         }
         gen.writeEndArray()
 


### PR DESCRIPTION
<!--
THANK YOU for your Pull Request. Please provide additional information about proposed 
changes below.

Code changes (e.g. bug fixes and new features) should include:
- tests
- documentation

Contributors guide: https://github.com/Kr1ptal/ethers-kt/blob/master/CONTRIBUTING.md
-->

## Description

Introduces the `IntoCallRequest` interface, and implements it for `Transaction`/`CallRequest`/`ReadContractCall` types. The PR also replaces the `CallRequest` argument types in `Provider` with the new interface.

This change makes it possible to e.g. trace mempool transactions without manually converting it to `CallRequest` or to combine contract calls with transactions in the newly added `eth_callMany`/`debug_traceCallMany` RPC calls.

<!--
Please provide the context and rationale for your proposed changes. 

What is the specific issue you intend to address? In some cases, no issue exists, and you should provide
the motivation for making this change.
-->

## Solution

<!--
Please provide a concise summary of the solution and offer the context required for 
understanding the code changes.

If you have any pseudocode, sketches, snapshots, links or other resources explaining
the solution, please include those as well.
-->
