### PR TITLE
fix(core): don't include logs from failed CallTracer frames

### DIFF
--- a/ethers-core/src/main/kotlin/io/ethers/core/types/tracers/CallTracer.kt
+++ b/ethers-core/src/main/kotlin/io/ethers/core/types/tracers/CallTracer.kt
@@ -56,6 +56,12 @@ data class CallTracer(
         val value: BigInteger? = null,
     ) {
         /**
+         * Return `true` if this call failed, false otherwise.
+         * */
+        val isError: Boolean
+            get() = error != null || revertReason != null
+
+        /**
          * Flatten this call frame and all sub-calls into a list of call frames. The list is ordered such that
          * parent call comes before child calls.
          * */
@@ -91,7 +97,7 @@ data class CallTracer(
 
         private fun addAllCallLogs(ret: MutableList<Log>): List<Log> {
             // if the call failed, skip it and all its children logs
-            if (error != null || revertReason != null) {
+            if (isError) {
                 return ret
             }
 

--- a/ethers-core/src/main/kotlin/io/ethers/core/types/tracers/CallTracer.kt
+++ b/ethers-core/src/main/kotlin/io/ethers/core/types/tracers/CallTracer.kt
@@ -90,6 +90,11 @@ data class CallTracer(
         }
 
         private fun addAllCallLogs(ret: MutableList<Log>): List<Log> {
+            // if the call failed, skip it and all its children logs
+            if (error != null || revertReason != null) {
+                return ret
+            }
+
             // first, add logs from child calls since they are emitted before logs from current call
             calls?.let {
                 for (i in it.indices) {


### PR DESCRIPTION
<!--
THANK YOU for your Pull Request. Please provide additional information about proposed 
changes below.

Code changes (e.g. bug fixes and new features) should include:
- tests
- documentation

Contributors guide: https://github.com/Kr1ptal/ethers-kt/blob/master/CONTRIBUTING.md
-->

## Description

Skip failed call frames also locally, just in case there are some discrepancies between different node tracer implementations. See: https://github.com/paradigmxyz/evm-inspectors/pull/52

<!--
Please provide the context and rationale for your proposed changes. 

What is the specific issue you intend to address? In some cases, no issue exists, and you should provide
the motivation for making this change.
-->

## Solution

<!--
Please provide a concise summary of the solution and offer the context required for 
understanding the code changes.

If you have any pseudocode, sketches, snapshots, links or other resources explaining
the solution, please include those as well.
-->
