### PR TITLE
fix!(abi): change `ConstructorCall#call` result to include all state changes made by contract deployment

### DIFF
--- a/ethers-abi/src/main/kotlin/io/ethers/abi/call/FunctionCall.kt
+++ b/ethers-abi/src/main/kotlin/io/ethers/abi/call/FunctionCall.kt
@@ -1,10 +1,18 @@
 package io.ethers.abi.call
 
+import io.ethers.abi.error.ContractError
+import io.ethers.abi.error.DecodingError
+import io.ethers.core.Result
+import io.ethers.core.failure
 import io.ethers.core.success
+import io.ethers.core.types.AccountOverride
 import io.ethers.core.types.Address
+import io.ethers.core.types.BlockId
+import io.ethers.core.types.BlockOverride
 import io.ethers.core.types.Bytes
 import io.ethers.providers.middleware.Middleware
 import io.ethers.providers.types.PendingTransaction
+import io.ethers.providers.types.RpcRequest
 import java.math.BigInteger
 import java.util.function.Function
 
@@ -14,6 +22,8 @@ class FunctionCall<T>(
     data: Bytes?,
     private val decoder: Function<Bytes, T>,
 ) : ReadWriteContractCall<T, PendingTransaction, FunctionCall<T>>(provider), Multicall3.Aggregatable<T> {
+    // NOTE: not intended for general use. Used only in Multicall3#aggregateCalls function where we need a call on which
+    // we can set a value, but not allow consumers to change it.
     internal constructor(
         provider: Middleware,
         to: Address,
@@ -32,7 +42,24 @@ class FunctionCall<T>(
     override val self: FunctionCall<T>
         get() = this
 
-    override fun handleCallResult(result: Bytes) = success(decoder.apply(result))
+    override fun doCall(
+        blockId: BlockId,
+        stateOverride: Map<Address, AccountOverride>?,
+        blockOverride: BlockOverride?,
+    ): RpcRequest<T, ContractError> {
+        return provider.call(call, blockId, stateOverride, blockOverride)
+            .mapError(::tryDecodingContractRevert)
+            .andThen(::decodeCallResult)
+    }
+
+    override fun decodeCallResult(result: Bytes): Result<T, ContractError> {
+        return try {
+            success(decoder.apply(result))
+        } catch (e: Exception) {
+            failure(DecodingError(result, "Unable to decode result", e))
+        }
+    }
+
     override fun handleSendResult(result: PendingTransaction) = result
 }
 
@@ -51,7 +78,23 @@ class ReadFunctionCall<T>(
     override val self: ReadFunctionCall<T>
         get() = this
 
-    override fun handleCallResult(result: Bytes) = success(decoder.apply(result))
+    override fun doCall(
+        blockId: BlockId,
+        stateOverride: Map<Address, AccountOverride>?,
+        blockOverride: BlockOverride?,
+    ): RpcRequest<T, ContractError> {
+        return provider.call(call, blockId, stateOverride, blockOverride)
+            .mapError(::tryDecodingContractRevert)
+            .andThen(::decodeCallResult)
+    }
+
+    override fun decodeCallResult(result: Bytes): Result<T, ContractError> {
+        return try {
+            success(decoder.apply(result))
+        } catch (e: Exception) {
+            failure(DecodingError(result, "Unable to decode result", e))
+        }
+    }
 }
 
 class PayableFunctionCall<T>(
@@ -69,7 +112,24 @@ class PayableFunctionCall<T>(
     override val self: PayableFunctionCall<T>
         get() = this
 
-    override fun handleCallResult(result: Bytes) = success(decoder.apply(result))
+    override fun doCall(
+        blockId: BlockId,
+        stateOverride: Map<Address, AccountOverride>?,
+        blockOverride: BlockOverride?,
+    ): RpcRequest<T, ContractError> {
+        return provider.call(call, blockId, stateOverride, blockOverride)
+            .mapError(::tryDecodingContractRevert)
+            .andThen(::decodeCallResult)
+    }
+
+    override fun decodeCallResult(result: Bytes): Result<T, ContractError> {
+        return try {
+            success(decoder.apply(result))
+        } catch (e: Exception) {
+            failure(DecodingError(result, "Unable to decode result", e))
+        }
+    }
+
     override fun handleSendResult(result: PendingTransaction) = result
 
     override var value: BigInteger?
@@ -100,6 +160,19 @@ class ReceiveFunctionCall(
     override val self: ReceiveFunctionCall
         get() = this
 
-    override fun handleCallResult(result: Bytes) = UNIT_RESPONSE
+    override fun doCall(
+        blockId: BlockId,
+        stateOverride: Map<Address, AccountOverride>?,
+        blockOverride: BlockOverride?,
+    ): RpcRequest<Unit, ContractError> {
+        return provider.call(call, blockId, stateOverride, blockOverride)
+            .mapError(::tryDecodingContractRevert)
+            .andThen(::decodeCallResult)
+    }
+
+    override fun decodeCallResult(result: Bytes): Result<Unit, ContractError> {
+        return UNIT_RESPONSE
+    }
+
     override fun handleSendResult(result: PendingTransaction) = result
 }

--- a/ethers-abi/src/main/kotlin/io/ethers/abi/call/Multicall3.kt
+++ b/ethers-abi/src/main/kotlin/io/ethers/abi/call/Multicall3.kt
@@ -490,6 +490,9 @@ class Multicall3(
         val allowFailure: Boolean
             get() = false
 
+        /**
+         * Safely decode the result of the call, returning the decoded value or a [ContractError] if decoding fails.
+         * */
         fun decodeCallResult(result: Bytes): io.ethers.core.Result<T, ContractError>
 
         /**


### PR DESCRIPTION
<!--
THANK YOU for your Pull Request. Please provide additional information about proposed 
changes below.

Code changes (e.g. bug fixes and new features) should include:
- tests
- documentation

Contributors guide: https://github.com/Kr1ptal/ethers-kt/blob/master/CONTRIBUTING.md
-->

## Description

Change `ContractCall#call` to deploy via `debug_traceCall` to get the full state diff, which includes:
- the deployed contract bytecode,
- contracts that might have been created in the constructor,
- storage slots that might have been written in the constructor

<!--
Please provide the context and rationale for your proposed changes. 

What is the specific issue you intend to address? In some cases, no issue exists, and you should provide
the motivation for making this change.
-->

## Solution

<!--
Please provide a concise summary of the solution and offer the context required for 
understanding the code changes.

If you have any pseudocode, sketches, snapshots, links or other resources explaining
the solution, please include those as well.
-->
