### PR TITLE
feat(providers): return a failure response instead of throwing if pub-sub not available in `Provider#subscribe*` methods

### DIFF
--- a/ethers-providers/src/main/kotlin/io/ethers/providers/Provider.kt
+++ b/ethers-providers/src/main/kotlin/io/ethers/providers/Provider.kt
@@ -52,6 +52,7 @@ import io.ethers.providers.types.RpcCall
 import io.ethers.providers.types.RpcRequest
 import io.ethers.providers.types.RpcSubscribe
 import io.ethers.providers.types.RpcSubscribeCall
+import io.ethers.providers.types.RpcSubscribeConstant
 import java.math.BigInteger
 import java.util.Optional
 import java.util.function.Function
@@ -367,9 +368,16 @@ class Provider(override val client: JsonRpcClient, override val chainId: Long) :
         decoder: Function<JsonParser, T>,
     ): RpcSubscribe<T, RpcError> {
         if (!isPubSub) {
-            throw UnsupportedOperationException("Pub/sub is not supported by this provider")
+            return RpcSubscribeConstant(
+                failure(
+                    RpcError(
+                        RpcError.CODE_METHOD_NOT_FOUND,
+                        "'eth_subscribe' is available only through a WS connection",
+                        null,
+                    ),
+                ),
+            )
         }
-
         return RpcSubscribeCall(client as JsonPubSubClient, params, decoder)
     }
 

--- a/ethers-providers/src/main/kotlin/io/ethers/providers/types/RpcSubscribe.kt
+++ b/ethers-providers/src/main/kotlin/io/ethers/providers/types/RpcSubscribe.kt
@@ -59,6 +59,20 @@ interface RpcSubscribe<T, E : Result.Error> {
 }
 
 /**
+ * Internal implementation of [RpcSubscribe] which always returns the same value.
+ * */
+internal class RpcSubscribeConstant<T, E : Result.Error>(
+    private val value: Result<SubscriptionStream<T>, E>,
+) : RpcSubscribe<T, E> {
+    override fun sendAwait(): Result<SubscriptionStream<T>, E> = value
+    override fun sendAsync(): CompletableFuture<Result<SubscriptionStream<T>, E>> {
+        return CompletableFuture.completedFuture(value)
+    }
+
+    override fun toString(): String = "RpcSubscribeConstant(value=$value)"
+}
+
+/**
  * Normal stream subscription via RPC.
  */
 class RpcSubscribeCall<T>(


### PR DESCRIPTION
<!--
THANK YOU for your Pull Request. Please provide additional information about proposed 
changes below.

Code changes (e.g. bug fixes and new features) should include:
- tests
- documentation

Contributors guide: https://github.com/Kr1ptal/ethers-kt/blob/master/CONTRIBUTING.md
-->

## Description

<!--
Please provide the context and rationale for your proposed changes. 

What is the specific issue you intend to address? In some cases, no issue exists, and you should provide
the motivation for making this change.
-->

## Solution

<!--
Please provide a concise summary of the solution and offer the context required for 
understanding the code changes.

If you have any pseudocode, sketches, snapshots, links or other resources explaining
the solution, please include those as well.
-->
