### PR TITLE
refactor(providers): treat failed transaction as successful inclusion result in `PendingInclusion`

### DIFF
--- a/ethers-providers/src/main/kotlin/io/ethers/providers/types/PendingInclusion.kt
+++ b/ethers-providers/src/main/kotlin/io/ethers/providers/types/PendingInclusion.kt
@@ -2,8 +2,6 @@ package io.ethers.providers.types
 
 import io.ethers.core.Result
 import io.ethers.core.types.Hash
-import io.ethers.core.types.TransactionReceipt
-import io.ethers.providers.RpcError
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
 
@@ -89,7 +87,6 @@ interface PendingInclusion<T> {
 
     sealed class Error : Result.Error {
         data class NoInclusion(val txHash: Hash, val retries: Int) : Error()
-        data class TxFailed(val txHash: Hash, val receipt: TransactionReceipt) : Error()
         data class RpcError(val txHash: Hash, val error: io.ethers.providers.RpcError) : Error()
     }
 }

--- a/ethers-providers/src/main/kotlin/io/ethers/providers/types/PendingTransaction.kt
+++ b/ethers-providers/src/main/kotlin/io/ethers/providers/types/PendingTransaction.kt
@@ -48,10 +48,6 @@ class PendingTransaction(
             return failure(PendingInclusion.Error.NoInclusion(hash, retries))
         }
 
-        if (!included.isSuccessful) {
-            return failure(PendingInclusion.Error.TxFailed(hash, included))
-        }
-
         if (confirmations <= 1) {
             return success(included)
         }


### PR DESCRIPTION
<!--
THANK YOU for your Pull Request. Please provide additional information about proposed 
changes below.

Code changes (e.g. bug fixes and new features) should include:
- tests
- documentation

Contributors guide: https://github.com/Kr1ptal/ethers-kt/blob/master/CONTRIBUTING.md
-->

## Description
A failed transaction is still an inclusion in a block. Simplifies error handling: instead of having to look for a failed receipt via error matching, you now always get a receipt as long as the tx has been included.

<!--
Please provide the context and rationale for your proposed changes. 

What is the specific issue you intend to address? In some cases, no issue exists, and you should provide
the motivation for making this change.
-->

## Solution

<!--
Please provide a concise summary of the solution and offer the context required for 
understanding the code changes.

If you have any pseudocode, sketches, snapshots, links or other resources explaining
the solution, please include those as well.
-->
