### PR TITLE
feat(examples): simulate block transactions with provider.traceCall a…

### DIFF
--- a/examples/src/main/kotlin/io/ethers/examples/batchrequests/SimulateBlockTransactions.kt
+++ b/examples/src/main/kotlin/io/ethers/examples/batchrequests/SimulateBlockTransactions.kt
@@ -1,6 +1,5 @@
 package io.ethers.examples.batchrequests
 
-import io.ethers.core.isFailure
 import io.ethers.core.types.StateOverride
 import io.ethers.core.types.toBlockOverride
 import io.ethers.core.types.tracers.CallTracer
@@ -38,12 +37,7 @@ class SimulateBlockTransactions(
 
                 // The Transaction (including RPCTransaction) implements the IntoCallRequest interface,
                 // allowing it to be directly utilized in the call without the need for manual conversion to CallRequest.
-                val unwrappedResult = provider.traceCall(tx, head.number - 1, config).sendAwait()
-                if (unwrappedResult.isFailure()) {
-                    continue
-                }
-
-                val result = unwrappedResult.unwrap()
+                val result = provider.traceCall(tx, head.number - 1, config).sendAwait().unwrap()
 
                 // Accumulate all changes made by transactions, upon which subsequent transactions are executed.
                 // This mirrors the process of building a block on the node.

--- a/examples/src/main/kotlin/io/ethers/examples/batchrequests/SimulateBlockTransactions.kt
+++ b/examples/src/main/kotlin/io/ethers/examples/batchrequests/SimulateBlockTransactions.kt
@@ -1,0 +1,73 @@
+package io.ethers.examples.batchrequests
+
+import io.ethers.core.isFailure
+import io.ethers.core.types.StateOverride
+import io.ethers.core.types.toBlockOverride
+import io.ethers.core.types.tracers.CallTracer
+import io.ethers.core.types.tracers.MuxTracer
+import io.ethers.core.types.tracers.PrestateTracer
+import io.ethers.core.types.tracers.TracerConfig
+import io.ethers.providers.Provider
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ArgType
+import kotlinx.cli.required
+
+class SimulateBlockTransactions(
+    rpcUrl: String,
+) {
+    // Init provider
+    private val provider = Provider.fromUrl(rpcUrl).unwrap()
+
+    fun run() {
+        // For each new block, simulate all transactions in the block with traceCall
+        provider.subscribeNewHeads().sendAwait().unwrap().forEach { head ->
+            println("New block: ${head.number}")
+
+            val blockWithTransactions = provider.getBlockWithTransactions(head.number).sendAwait().unwrap()
+            val stateOverrides = StateOverride.copy(emptyMap())
+            val blockOverrides = blockWithTransactions.toBlockOverride()
+            for (tx in blockWithTransactions.transactions) {
+                val txReceipt = provider.getTransactionReceipt(tx.hash).sendAwait().unwrap().get()
+                val config = TracerConfig(
+                    tracer = MULTICALL_MUX_TRACER,
+                    stateOverrides = stateOverrides,
+                    blockOverrides = blockOverrides,
+                )
+                val unwrappedResult = provider.traceCall(tx, head.number, config).sendAwait()
+                if (unwrappedResult.isFailure()) {
+                    continue
+                }
+
+                val result = unwrappedResult.unwrap()
+                stateOverrides.takeChanges(result[PrestateTracer::class.java].toStateOverride())
+
+                val call = result[CallTracer::class.java]
+
+                if (!call.isError == txReceipt.isSuccessful && call.gasUsed == txReceipt.gasUsed) {
+                    println("Transaction simulation ${tx.hash} was correct")
+                } else {
+                    println("Transaction simulation ${tx.hash} was incorrect")
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val MULTICALL_MUX_TRACER = MuxTracer(
+            PrestateTracer(diffMode = true),
+            CallTracer(onlyTopCall = true, withLog = true),
+        )
+    }
+}
+
+fun main(args: Array<String>) {
+    // Parse input arguments
+    val argParser = ArgParser("IntoCallRequest")
+
+    // Problems with public ws rpc url - add your own
+    val rpcUrl by argParser.option(ArgType.String, description = "RPC URL").required()
+
+    argParser.parse(args)
+
+    SimulateBlockTransactions(rpcUrl).run()
+}


### PR DESCRIPTION
…nd IntoCallRequest

<!--
THANK YOU for your Pull Request. Please provide additional information about proposed 
changes below.

Code changes (e.g. bug fixes and new features) should include:
- tests
- documentation

Contributors guide: https://github.com/Kr1ptal/ethers-kt/blob/master/CONTRIBUTING.md
-->

## Description

<!--
Please provide the context and rationale for your proposed changes. 

What is the specific issue you intend to address? In some cases, no issue exists, and you should provide
the motivation for making this change.
-->

We want to show how to subscribe to new block heads and simulate transactions in the block.

## Solution

<!--
Please provide a concise summary of the solution and offer the context required for 
understanding the code changes.

If you have any pseudocode, sketches, snapshots, links or other resources explaining
the solution, please include those as well.
-->

We implemented the solution using provider.subscribeNewHeads() for subscription to new blocks and provider.traceCall for transaction simulation.
