### PR TITLE
feat(core): Add constructor for hex strings to Signature

### DIFF
--- a/ethers-core/src/main/kotlin/io/ethers/core/types/Signature.kt
+++ b/ethers-core/src/main/kotlin/io/ethers/core/types/Signature.kt
@@ -203,12 +203,8 @@ class Signature(
                 return failure(InvalidSignatureError("Invalid hex format: $hexString"))
             }
 
-            return try {
-                val byteArray = FastHex.decode(hexString)
-                fromByteArray(byteArray)
-            } catch (e: Exception) {
-                failure(InvalidSignatureError("Failed to decode hex: ${e.message}"))
-            }
+            val byteArray = FastHex.decode(hexString)
+            return fromByteArray(byteArray)
         }
     }
 }

--- a/ethers-core/src/main/kotlin/io/ethers/core/types/Signature.kt
+++ b/ethers-core/src/main/kotlin/io/ethers/core/types/Signature.kt
@@ -156,6 +156,12 @@ class Signature(
         rlp.encode(s)
     }
 
+    constructor(hexString: String) : this(
+        r = BigInteger(1, hexString.substring(0, 64).hexStringToByteArray()),
+        s = BigInteger(1, hexString.substring(64, 128).hexStringToByteArray()),
+        v = hexString.substring(128).hexStringToByteArray()[0].toLong(),
+    )
+
     companion object : RlpDecodable<Signature> {
         const val V_ELECTRUM_OFFSET = 27L
         const val V_EIP155_OFFSET = 35L
@@ -183,6 +189,13 @@ class Signature(
             val s = BigInteger(1, byteArray, 32, 32)
             val v = byteArray[64].toLong()
             return success(Signature(r, s, v))
+        }
+
+        private fun String.hexStringToByteArray(): ByteArray {
+            check(length % 2 == 0) { "Hex string must have an even length" }
+            return chunked(2)
+                .map { it.toInt(16).toByte() }
+                .toByteArray()
         }
     }
 }

--- a/ethers-core/src/test/kotlin/io/ethers/core/types/SignatureTest.kt
+++ b/ethers-core/src/test/kotlin/io/ethers/core/types/SignatureTest.kt
@@ -69,50 +69,35 @@ class SignatureTest : FunSpec({
         }
     }
 
-    context("fromHex") {
-        test("fromHex should decode valid hex strings correctly") {
-            val testData =
-                mapOf(
-                    "000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000bdd6991b" to
-                        Signature(
-                            "10".toBigInteger(),
-                            "12441241".toBigInteger(),
-                            27L,
-                        ),
-                    "000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000bdd6991c" to
-                        Signature(
-                            "10".toBigInteger(),
-                            "12441241".toBigInteger(),
-                            28L,
-                        ),
-                )
-
-            testData.forEach { (hex, expectedSignature) ->
-                val result = Signature.fromHex(hex)
-                result.isSuccess() shouldBe true
-                result.unwrap() shouldBe expectedSignature
-            }
+    context("fromHex should decode valid hex strings correctly") {
+        withData(
+            "000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000bdd6991b" to
+                Signature(
+                    "10".toBigInteger(),
+                    "12441241".toBigInteger(),
+                    27L,
+                ),
+            "000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000bdd6991c" to
+                Signature(
+                    "10".toBigInteger(),
+                    "12441241".toBigInteger(),
+                    28L,
+                ),
+        ) { (hex, expectedSignature) ->
+            val result = Signature.fromHex(hex)
+            result.isSuccess() shouldBe true
+            result.unwrap() shouldBe expectedSignature
         }
+    }
 
-        test("fromHex should fail with an InvalidSignatureError for invalid hex formats") {
-            val invalidHex = "0x" + "1".repeat(64)
-
-            val result = Signature.fromHex(invalidHex)
+    context("fromHex should handle invalid formats and sizes correctly") {
+        withData(
+            "0x" + "1".repeat(64),
+            "1".repeat(200),
+        ) { hex ->
+            val result = Signature.fromHex(hex)
             result.isFailure() shouldBe true
             result.unwrapOrNull()?.shouldBeInstanceOf<InvalidSignatureError>()
-        }
-
-        test("fromHex should handle empty and excessively long strings") {
-            val emptyHex = ""
-            val longHex = "1".repeat(200) // Assume this is longer than needed
-
-            val emptyResult = Signature.fromHex(emptyHex)
-            emptyResult.isFailure() shouldBe true
-            emptyResult.unwrapOrNull()?.shouldBeInstanceOf<InvalidSignatureError>()
-
-            val longResult = Signature.fromHex(longHex)
-            longResult.isFailure() shouldBe true
-            longResult.unwrapOrNull()?.shouldBeInstanceOf<InvalidSignatureError>()
         }
     }
 })

--- a/ethers-core/src/test/kotlin/io/ethers/core/types/SignatureTest.kt
+++ b/ethers-core/src/test/kotlin/io/ethers/core/types/SignatureTest.kt
@@ -1,18 +1,22 @@
 package io.ethers.core.types
 
+import io.ethers.core.isFailure
+import io.ethers.core.isSuccess
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import java.math.BigInteger
 
 class SignatureTest : FunSpec({
     context("invalid recoveryId") {
-        val invalidSignature = Signature(
-            v = Signature.V_EIP155_OFFSET - 1,
-            r = BigInteger.ZERO,
-            s = BigInteger.ZERO,
-        )
+        val invalidSignature =
+            Signature(
+                v = Signature.V_EIP155_OFFSET - 1,
+                r = BigInteger.ZERO,
+                s = BigInteger.ZERO,
+            )
 
         test("recoveryId() fails") {
             shouldThrow<IllegalStateException> {
@@ -27,17 +31,88 @@ class SignatureTest : FunSpec({
 
     context("toByteArray/fromByteArray") {
         withData(
-            Signature("10".toBigInteger(), "12441241".toBigInteger(), 27L) to "000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000bdd6991b",
-            Signature("10".toBigInteger(), "12441241".toBigInteger(), 28L) to "000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000bdd6991c",
-            Signature("18515461264373351373200002665853028612451056578545711640558177340181847433846".toBigInteger(), "46948507304638947509940763649030358759909902576025900602547168820602576006531".toBigInteger(), 27L) to "28ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa63627667cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d831b",
-            Signature("46948507304638947509940763649030358759909902576025900602547168820602576006531".toBigInteger(), "18515461264373351373200002665853028612451056578545711640558177340181847433846".toBigInteger(), 28L) to "67cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d8328ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa6362761c",
-            Signature("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".toBigInteger(16), "46948507304638947509940763649030358759909902576025900602547168820602576006531".toBigInteger(), 28L) to "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff67cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d831c",
-            Signature("18515461264373351373200002665853028612451056578545711640558177340181847433846".toBigInteger(), "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".toBigInteger(16), 27L) to "28ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1b",
+            Signature(
+                "10".toBigInteger(),
+                "12441241".toBigInteger(),
+                27L,
+            ) to "000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000bdd6991b",
+            Signature(
+                "10".toBigInteger(),
+                "12441241".toBigInteger(),
+                28L,
+            ) to "000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000bdd6991c",
+            Signature(
+                "18515461264373351373200002665853028612451056578545711640558177340181847433846".toBigInteger(),
+                "46948507304638947509940763649030358759909902576025900602547168820602576006531".toBigInteger(),
+                27L,
+            ) to "28ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa63627667cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d831b",
+            Signature(
+                "46948507304638947509940763649030358759909902576025900602547168820602576006531".toBigInteger(),
+                "18515461264373351373200002665853028612451056578545711640558177340181847433846".toBigInteger(),
+                28L,
+            ) to "67cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d8328ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa6362761c",
+            Signature(
+                "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".toBigInteger(16),
+                "46948507304638947509940763649030358759909902576025900602547168820602576006531".toBigInteger(),
+                28L,
+            ) to "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff67cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d831c",
+            Signature(
+                "18515461264373351373200002665853028612451056578545711640558177340181847433846".toBigInteger(),
+                "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".toBigInteger(16),
+                27L,
+            ) to "28ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1b",
         ) { (signature, expected) ->
             val bytes = signature.toByteArray()
             bytes.toHexString() shouldBe expected
 
             Signature.fromByteArray(bytes).unwrap() shouldBe signature
+        }
+    }
+
+    context("fromHex") {
+        test("fromHex should decode valid hex strings correctly") {
+            val testData =
+                mapOf(
+                    "000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000bdd6991b" to
+                        Signature(
+                            "10".toBigInteger(),
+                            "12441241".toBigInteger(),
+                            27L,
+                        ),
+                    "000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000bdd6991c" to
+                        Signature(
+                            "10".toBigInteger(),
+                            "12441241".toBigInteger(),
+                            28L,
+                        ),
+                )
+
+            testData.forEach { (hex, expectedSignature) ->
+                val result = Signature.fromHex(hex)
+                result.isSuccess() shouldBe true
+                result.unwrap() shouldBe expectedSignature
+            }
+        }
+
+        test("fromHex should fail with an InvalidSignatureError for invalid hex formats") {
+            val invalidHex = "0x" + "1".repeat(64)
+
+            val result = Signature.fromHex(invalidHex)
+            result.isFailure() shouldBe true
+            result.unwrapOrNull()?.shouldBeInstanceOf<InvalidSignatureError>()
+        }
+
+        test("fromHex should handle empty and excessively long strings") {
+            val emptyHex = ""
+            val longHex = "1".repeat(200) // Assume this is longer than needed
+
+            val emptyResult = Signature.fromHex(emptyHex)
+            emptyResult.isFailure() shouldBe true
+            emptyResult.unwrapOrNull()?.shouldBeInstanceOf<InvalidSignatureError>()
+
+            val longResult = Signature.fromHex(longHex)
+            longResult.isFailure() shouldBe true
+            longResult.unwrapOrNull()?.shouldBeInstanceOf<InvalidSignatureError>()
         }
     }
 })


### PR DESCRIPTION
<!--
THANK YOU for your Pull Request. Please provide additional information about proposed 
changes below.

Code changes (e.g. bug fixes and new features) should include:
- tests
- documentation

Contributors guide: https://github.com/Kr1ptal/ethers-kt/blob/master/CONTRIBUTING.md
-->

## Description

<!--
Please provide the context and rationale for your proposed changes. 

What is the specific issue you intend to address? In some cases, no issue exists, and you should provide
the motivation for making this change.
-->

Resolve issue Add constructor for hex strings to Signature #16

## Solution

<!--
Please provide a concise summary of the solution and offer the context required for 
understanding the code changes.

If you have any pseudocode, sketches, snapshots, links or other resources explaining
the solution, please include those as well.
-->

We added a constructor to Signature class that takes a hex String and decodes it to Signature.
