### PR TITLE
perf(core): add `toString` cache for `Address`/`Hash`/`Bytes` types

### DIFF
--- a/ethers-core/src/jmh/java/io/ethers/core/types/AddressSerializationBenchmark.kt
+++ b/ethers-core/src/jmh/java/io/ethers/core/types/AddressSerializationBenchmark.kt
@@ -1,0 +1,59 @@
+package io.ethers.core.types
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OperationsPerInvocation
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+import org.openjdk.jmh.profile.GCProfiler
+import org.openjdk.jmh.runner.Runner
+import org.openjdk.jmh.runner.options.OptionsBuilder
+import java.util.concurrent.TimeUnit
+
+@Fork(value = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+open class AddressSerializationBenchmark {
+
+    @Benchmark
+    @OperationsPerInvocation(1024 * 10)
+    fun toStringRandom(bh: Blackhole, state: BenchState) {
+        for (address in state.random) {
+            bh.consume(address)
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(1024 * 10)
+    fun toStringDuplicate50(bh: Blackhole, state: BenchState) {
+        for (address in state.duplicate50) {
+            bh.consume(address.toString())
+        }
+    }
+
+    @State(Scope.Benchmark)
+    open class BenchState {
+        private val duplicate = Address.random()
+        val random = Array(1024 * 10) { Address.random() }
+        val duplicate50 = Array(1024 * 2) { Address.random() } + Array(1024 * 2) { duplicate } +
+            Array(1024 * 2) { Address.random() } + Array(1024 * 2) { duplicate } +
+            Array(1024 * 2) { Address.random() }
+    }
+
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) {
+            val options = OptionsBuilder()
+                .include(AddressSerializationBenchmark::class.java.simpleName)
+                .addProfiler(GCProfiler::class.java)
+                .warmupIterations(3)
+                .measurementIterations(3)
+                .build()
+            Runner(options).run()
+        }
+    }
+}

--- a/ethers-core/src/jmh/java/io/ethers/core/types/HashSerializationBenchmark.kt
+++ b/ethers-core/src/jmh/java/io/ethers/core/types/HashSerializationBenchmark.kt
@@ -1,0 +1,64 @@
+package io.ethers.core.types
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OperationsPerInvocation
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+import org.openjdk.jmh.profile.GCProfiler
+import org.openjdk.jmh.runner.Runner
+import org.openjdk.jmh.runner.options.OptionsBuilder
+import java.util.concurrent.TimeUnit
+import kotlin.random.Random
+
+@Fork(value = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+open class HashSerializationBenchmark {
+
+    @Benchmark
+    @OperationsPerInvocation(1024 * 10)
+    fun toStringRandom(bh: Blackhole, state: BenchState) {
+        for (address in state.random) {
+            bh.consume(address)
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(1024 * 10)
+    fun toStringDuplicate50(bh: Blackhole, state: BenchState) {
+        for (address in state.duplicate50) {
+            bh.consume(address.toString())
+        }
+    }
+
+    @State(Scope.Benchmark)
+    open class BenchState {
+        private val duplicate = Hash.random()
+        val random = Array(1024 * 10) { Hash.random() }
+        val duplicate50 = Array(1024 * 2) { Hash.random() } + Array(1024 * 2) { duplicate } +
+            Array(1024 * 2) { Hash.random() } + Array(1024 * 2) { duplicate } +
+            Array(1024 * 2) { Hash.random() }
+    }
+
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) {
+            val options = OptionsBuilder()
+                .include(HashSerializationBenchmark::class.java.simpleName)
+                .addProfiler(GCProfiler::class.java)
+                .warmupIterations(3)
+                .measurementIterations(3)
+                .build()
+            Runner(options).run()
+        }
+    }
+}
+
+fun Hash.Companion.random(): Hash {
+    return Hash(Random.nextBytes(ByteArray(32)))
+}

--- a/ethers-core/src/main/kotlin/io/ethers/core/types/Address.kt
+++ b/ethers-core/src/main/kotlin/io/ethers/core/types/Address.kt
@@ -25,6 +25,9 @@ import kotlin.random.Random
 class Address(private val value: ByteArray) : RlpEncodable {
     constructor(value: CharSequence) : this(FastHex.decode(value))
 
+    // cache of hex string for faster serialization if serializing the same instance multiple times
+    private var stringCache: String? = null
+
     init {
         require(value.size == 20) { "Address must be 20 bytes long" }
     }
@@ -72,7 +75,7 @@ class Address(private val value: ByteArray) : RlpEncodable {
     }
 
     override fun toString(): String {
-        return FastHex.encodeWithPrefix(value)
+        return stringCache ?: FastHex.encodeWithPrefix(value).also { stringCache = it }
     }
 
     companion object : RlpDecodable<Address> {

--- a/ethers-core/src/main/kotlin/io/ethers/core/types/Bytes.kt
+++ b/ethers-core/src/main/kotlin/io/ethers/core/types/Bytes.kt
@@ -23,6 +23,9 @@ import io.ethers.rlp.RlpEncoder
 class Bytes(private val value: ByteArray) : RlpEncodable {
     constructor(value: CharSequence) : this(FastHex.decode(value))
 
+    // cache of hex string for faster serialization if serializing the same instance multiple times
+    private var stringCache: String? = null
+
     /**
      * Return the internal byte array.
      *
@@ -192,7 +195,7 @@ class Bytes(private val value: ByteArray) : RlpEncodable {
     }
 
     override fun toString(): String {
-        return FastHex.encodeWithPrefix(value)
+        return stringCache ?: FastHex.encodeWithPrefix(value).also { stringCache = it }
     }
 
     override fun rlpEncode(rlp: RlpEncoder) {

--- a/ethers-core/src/main/kotlin/io/ethers/core/types/Hash.kt
+++ b/ethers-core/src/main/kotlin/io/ethers/core/types/Hash.kt
@@ -24,6 +24,9 @@ class Hash(private val value: ByteArray) : RlpEncodable {
     constructor(value: CharSequence) : this(FastHex.decode(value))
     constructor(value: Address) : this(value.asByteArray().copyInto(ByteArray(32), 12))
 
+    // cache of hex string for faster serialization if serializing the same instance multiple times
+    private var stringCache: String? = null
+
     init {
         require(value.size == 32) { "Hash must be 32 bytes long" }
     }
@@ -71,7 +74,7 @@ class Hash(private val value: ByteArray) : RlpEncodable {
     }
 
     override fun toString(): String {
-        return FastHex.encodeWithPrefix(value)
+        return stringCache ?: FastHex.encodeWithPrefix(value).also { stringCache = it }
     }
 
     companion object : RlpDecodable<Hash> {


### PR DESCRIPTION
<!--
THANK YOU for your Pull Request. Please provide additional information about proposed 
changes below.

Code changes (e.g. bug fixes and new features) should include:
- tests
- documentation

Contributors guide: https://github.com/Kr1ptal/ethers-kt/blob/master/CONTRIBUTING.md
-->

## Description
Adds caching of `toString` function result on first call. This change improves performance when serializing the same instance multiple times.
<!--
Please provide the context and rationale for your proposed changes. 

What is the specific issue you intend to address? In some cases, no issue exists, and you should provide
the motivation for making this change.
-->

## Solution

<!--
Please provide a concise summary of the solution and offer the context required for 
understanding the code changes.

If you have any pseudocode, sketches, snapshots, links or other resources explaining
the solution, please include those as well.
-->
