### PR TITLE
feat(call-tracer): Support deserialization of other fields.

### DIFF
--- a/ethers-core/src/test/kotlin/io/ethers/core/types/tracers/CallTracerTest.kt
+++ b/ethers-core/src/test/kotlin/io/ethers/core/types/tracers/CallTracerTest.kt
@@ -62,7 +62,29 @@ class CallTracerTest : FunSpec({
                   "data": "0x04"
                 }
               ],
-              "value": "0x2964372534825c"
+              "value": "0x2964372534825c",
+              "beforeEVMTransfers": [
+                {
+                  "purpose": "feePayment",
+                  "from": "0x0000000000000000000000000000000000000000",
+                  "to": null,
+                  "value": "0x0"
+                }
+              ],
+              "afterEVMTransfers": [
+                {
+                  "purpose": "gasRefund",
+                  "from": null,
+                  "to": "0x0000000000000000000000000000000000000000",
+                  "value": "0x0"
+                },
+                {
+                  "purpose": "feeCollection",
+                  "from": null,
+                  "to": "0xbF5041Fc07E1c866D15c749156657B8eEd0fb649",
+                  "value": "0x42d1574900"
+                }
+              ]
             }
         """.trimIndent()
 
@@ -99,6 +121,10 @@ class CallTracerTest : FunSpec({
                 ),
             ),
             value = BigInteger("11650662055314012"),
+            otherFields = mapOf(
+                "beforeEVMTransfers" to Jackson.MAPPER.readTree("[{\"purpose\":\"feePayment\",\"from\":\"0x0000000000000000000000000000000000000000\",\"to\":null,\"value\":\"0x0\"}]"),
+                "afterEVMTransfers" to Jackson.MAPPER.readTree("[{\"purpose\":\"gasRefund\",\"from\":null,\"to\":\"0x0000000000000000000000000000000000000000\",\"value\":\"0x0\"},{\"purpose\":\"feeCollection\",\"from\":null,\"to\":\"0xbF5041Fc07E1c866D15c749156657B8eEd0fb649\",\"value\":\"0x42d1574900\"}]"),
+            ),
         )
 
         result shouldBe expectedResult


### PR DESCRIPTION
<!--
THANK YOU for your Pull Request. Please provide additional information about proposed 
changes below.

Code changes (e.g. bug fixes and new features) should include:
- tests
- documentation

Contributors guide: https://github.com/Kr1ptal/ethers-kt/blob/master/CONTRIBUTING.md
-->

## Description

On some chains `CallTracer` result returns additional fields that we haven't serialized yet. For example on Arbitrum call tracer returns:

```
{
  "jsonrpc": "2.0",
  "id": 248,
  "result": {
    "callTracer": {
      "beforeEVMTransfers": [
        {
          "purpose": "feePayment",
          "from": "0x0000000000000000000000000000000000000000",
          "to": null,
          "value": "0x0"
        }
      ],
      "afterEVMTransfers": [
        {
          "purpose": "gasRefund",
          "from": null,
          "to": "0x0000000000000000000000000000000000000000",
          "value": "0x0"
        },
        {
          "purpose": "feeCollection",
          "from": null,
          "to": "0xbF5041Fc07E1c866D15c749156657B8eEd0fb649",
          "value": "0x42d1574900"
        },
        {
          "purpose": "feeCollection",
          "from": null,
          "to": "0x32e7AF5A8151934F3787d0cD59EB6EDd0a736b1d",
          "value": "0x92ada4fc0"
        },
        {
          "purpose": "feeCollection",
          "from": null,
          "to": "0xa4B00000000000000000000000000000000000F6",
          "value": "0x25d6c877a0"
        }
      ],
      "from": "0x0000000000000000000000000000000000000000",
      "gas": "0x2fb2853",
      "gasUsed": "0xa7ed",
      "to": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
      "input": "0xd0e30db0",
      "output": "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001f45524332303a206d696e7420746f20746865207a65726f206164647265737300",
      "error": "execution reverted",
      "revertReason": "ERC20: mint to the zero address",
      "calls": [
        {
          "from": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
          "gas": "0x2ee9811",
          "gasUsed": "0x17d",
          "to": "0x8b194beae1d3e0788a1a35173978001acdfba668",
          "input": "0xd0e30db0",
          "output": "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001f45524332303a206d696e7420746f20746865207a65726f206164647265737300",
          "error": "execution reverted",
          "revertReason": "ERC20: mint to the zero address",
          "value": "0x297e442deb7f5d0",
          "type": "DELEGATECALL"
        }
      ],
      "value": "0x297e442deb7f5d0",
      "type": "CALL"
    },
    "prestateTracer": {
      "post": {
        "0x0000000000000000000000000000000000000000": {
          "nonce": 1
        }
      },
      "pre": {
        "0x0000000000000000000000000000000000000000": {
          "balance": "0xf682cce4cecf07bb"
        }
      }
    }
  }
}
```

<!--
Please provide the context and rationale for your proposed changes. 

What is the specific issue you intend to address? In some cases, no issue exists, and you should provide
the motivation for making this change.
-->

## Solution

Use the principle from `RPCTransaction` where we store unrecognized fields in a map. 

<!--
Please provide a concise summary of the solution and offer the context required for 
understanding the code changes.

If you have any pseudocode, sketches, snapshots, links or other resources explaining
the solution, please include those as well.
-->
