### PR TITLE
feat: optimize struct ABI references and add typed StructFactory.abi

### DIFF
--- a/ethers-abi/src/main/kotlin/io/ethers/abi/ContractStruct.kt
+++ b/ethers-abi/src/main/kotlin/io/ethers/abi/ContractStruct.kt
@@ -3,15 +3,55 @@ package io.ethers.abi
 /**
  * A contract-defined struct. Supports converting its fields to a tuple, and creating a struct from a tuple
  * via [StructFactory].
- **/
+ *
+ * This interface represents smart contract struct types that can be encoded/decoded to/from ABI tuples.
+ * Implementations are typically generated automatically by the ethers-abigen module.
+ *
+ * @see StructFactory for creating instances from tuple data
+ */
 interface ContractStruct {
+    /**
+     * Converts this struct to a tuple representation for ABI encoding.
+     *
+     * @return ordered list of field values that can be ABI-encoded as a tuple
+     */
     val tuple: List<Any>
 }
 
 /**
- * Struct factory, used to create a [ContractStruct] from a tuple.
- * */
+ * Factory interface for creating [ContractStruct] instances from tuple data.
+ *
+ * This interface is typically implemented by companion objects of generated struct classes
+ * to provide both ABI type information and deserialization capabilities. It serves as the
+ * single source of truth for a struct's ABI definition and construction logic.
+ *
+ * @param T the specific [ContractStruct] type this factory creates
+ * @see ContractStruct for the struct interface
+ */
 interface StructFactory<T : ContractStruct> {
+    /**
+     * The ABI type definition for this struct.
+     *
+     * This property provides the complete ABI tuple specification for the struct,
+     * including field types and nested struct definitions. It serves as the canonical
+     * reference for ABI encoding/decoding operations and is used throughout the
+     * codebase to avoid duplicate ABI definitions.
+     *
+     * @return ABI tuple type parameterized with the struct type
+     */
     val abi: AbiType.Tuple<T>
+    
+    /**
+     * Creates a struct instance from tuple data.
+     *
+     * Deserializes ABI-decoded tuple data into a typed struct instance. The data
+     * list must contain values in the same order as defined in the struct's ABI
+     * tuple specification.
+     *
+     * @param data ordered list of decoded values matching the struct's field types
+     * @return typed struct instance with populated fields
+     * @throws IndexOutOfBoundsException if data list doesn't match expected field count
+     * @throws ClassCastException if data types don't match expected field types
+     */
     fun fromTuple(data: List<Any>): T
 }

--- a/ethers-abi/src/main/kotlin/io/ethers/abi/ContractStruct.kt
+++ b/ethers-abi/src/main/kotlin/io/ethers/abi/ContractStruct.kt
@@ -12,5 +12,6 @@ interface ContractStruct {
  * Struct factory, used to create a [ContractStruct] from a tuple.
  * */
 interface StructFactory<T : ContractStruct> {
+    val abi: AbiType.Tuple<T>
     fun fromTuple(data: List<Any>): T
 }

--- a/ethers-abi/src/main/kotlin/io/ethers/abi/ContractStruct.kt
+++ b/ethers-abi/src/main/kotlin/io/ethers/abi/ContractStruct.kt
@@ -40,7 +40,7 @@ interface StructFactory<T : ContractStruct> {
      * @return ABI tuple type parameterized with the struct type
      */
     val abi: AbiType.Tuple<T>
-    
+
     /**
      * Creates a struct instance from tuple data.
      *

--- a/ethers-abi/src/main/kotlin/io/ethers/abi/call/Multicall3.kt
+++ b/ethers-abi/src/main/kotlin/io/ethers/abi/call/Multicall3.kt
@@ -363,6 +363,9 @@ class Multicall3(
 
         companion object : StructFactory<Call> {
             @JvmStatic
+            override val abi: AbiType.Tuple<Call> = AbiType.Tuple.struct(Call::class, AbiType.Address, AbiType.Bytes)
+
+            @JvmStatic
             override fun fromTuple(data: List<Any>): Call = Call(data[0] as Address, data[1] as Bytes)
         }
     }
@@ -392,6 +395,9 @@ class Multicall3(
         }
 
         companion object : StructFactory<Call3> {
+            @JvmStatic
+            override val abi: AbiType.Tuple<Call3> = AbiType.Tuple.struct(Call3::class, AbiType.Address, AbiType.Bool, AbiType.Bytes)
+
             @JvmStatic
             override fun fromTuple(data: List<Any>): Call3 = Call3(
                 data[0] as Address,
@@ -430,6 +436,9 @@ class Multicall3(
 
         companion object : StructFactory<Call3Value> {
             @JvmStatic
+            override val abi: AbiType.Tuple<Call3Value> = AbiType.Tuple.struct(Call3Value::class, AbiType.Address, AbiType.Bool, AbiType.UInt(256), AbiType.Bytes)
+
+            @JvmStatic
             override fun fromTuple(data: List<Any>): Call3Value = Call3Value(
                 data[0] as Address,
                 data[1] as Boolean,
@@ -461,6 +470,9 @@ class Multicall3(
         }
 
         companion object : StructFactory<Result> {
+            @JvmStatic
+            override val abi: AbiType.Tuple<Result> = AbiType.Tuple.struct(Result::class, AbiType.Bool, AbiType.Bytes)
+
             @JvmStatic
             override fun fromTuple(data: List<Any>): Result = Result(data[0] as Boolean, data[1] as Bytes)
         }
@@ -576,36 +588,26 @@ class Multicall3(
         @JvmField
         val FUNCTION_AGGREGATE3: AbiFunction = AbiFunction(
             "aggregate3",
-            listOf(AbiType.Array(AbiType.Tuple.struct(Call3::class, AbiType.Address, AbiType.Bool, AbiType.Bytes))),
-            listOf(AbiType.Array(AbiType.Tuple.struct(Result::class, AbiType.Bool, AbiType.Bytes))),
+            listOf(AbiType.Array(Call3.abi)),
+            listOf(AbiType.Array(Result.abi)),
         )
 
         @JvmField
         val FUNCTION_BLOCK_AND_AGGREGATE: AbiFunction = AbiFunction(
             "blockAndAggregate",
-            listOf(AbiType.Array(AbiType.Tuple.struct(Call::class, AbiType.Address, AbiType.Bytes))),
+            listOf(AbiType.Array(Call.abi)),
             listOf(
                 AbiType.UInt(256),
                 AbiType.FixedBytes(32),
-                AbiType.Array(AbiType.Tuple.struct(Result::class, AbiType.Bool, AbiType.Bytes)),
+                AbiType.Array(Result.abi),
             ),
         )
 
         @JvmField
         val FUNCTION_AGGREGATE3_VALUE: AbiFunction = AbiFunction(
             "aggregate3Value",
-            listOf(
-                AbiType.Array(
-                    AbiType.Tuple.struct(
-                        Call3Value::class,
-                        AbiType.Address,
-                        AbiType.Bool,
-                        AbiType.UInt(256),
-                        AbiType.Bytes,
-                    ),
-                ),
-            ),
-            listOf(AbiType.Array(AbiType.Tuple.struct(Result::class, AbiType.Bool, AbiType.Bytes))),
+            listOf(AbiType.Array(Call3Value.abi)),
+            listOf(AbiType.Array(Result.abi)),
         )
 
         @JvmField
@@ -618,7 +620,7 @@ class Multicall3(
         @JvmField
         val FUNCTION_AGGREGATE: AbiFunction = AbiFunction(
             "aggregate",
-            listOf(AbiType.Array(AbiType.Tuple.struct(Call::class, AbiType.Address, AbiType.Bytes))),
+            listOf(AbiType.Array(Call.abi)),
             listOf(AbiType.UInt(256), AbiType.Array(AbiType.Bytes)),
         )
 
@@ -653,19 +655,19 @@ class Multicall3(
         @JvmField
         val FUNCTION_TRY_AGGREGATE: AbiFunction = AbiFunction(
             "tryAggregate",
-            listOf(AbiType.Bool, AbiType.Array(AbiType.Tuple.struct(Call::class, AbiType.Address, AbiType.Bytes))),
-            listOf(AbiType.Array(AbiType.Tuple.struct(Result::class, AbiType.Bool, AbiType.Bytes))),
+            listOf(AbiType.Bool, AbiType.Array(Call.abi)),
+            listOf(AbiType.Array(Result.abi)),
         )
 
         @JvmField
         val FUNCTION_TRY_BLOCK_AND_AGGREGATE: AbiFunction =
             AbiFunction(
                 "tryBlockAndAggregate",
-                listOf(AbiType.Bool, AbiType.Array(AbiType.Tuple.struct(Call::class, AbiType.Address, AbiType.Bytes))),
+                listOf(AbiType.Bool, AbiType.Array(Call.abi)),
                 listOf(
                     AbiType.UInt(256),
                     AbiType.FixedBytes(32),
-                    AbiType.Array(AbiType.Tuple.struct(Result::class, AbiType.Bool, AbiType.Bytes)),
+                    AbiType.Array(Result.abi),
                 ),
             )
 

--- a/ethers-abi/src/test/kotlin/io/ethers/abi/error/CustomErrorTest.kt
+++ b/ethers-abi/src/test/kotlin/io/ethers/abi/error/CustomErrorTest.kt
@@ -114,6 +114,9 @@ class CustomErrorTest : FunSpec({
 
         companion object : StructFactory<ErrorMsg> {
             @JvmStatic
+            override val abi: AbiType.Tuple<ErrorMsg> = AbiType.Tuple.struct(ErrorMsg::class, AbiType.String, AbiType.UInt(256), AbiType.Array(AbiType.Bool))
+
+            @JvmStatic
             override fun fromTuple(data: List<Any>): ErrorMsg = ErrorMsg(
                 data[0] as String,
                 data[1] as BigInteger,

--- a/ethers-abi/src/test/kotlin/io/ethers/abi/error/CustomErrorTest.kt
+++ b/ethers-abi/src/test/kotlin/io/ethers/abi/error/CustomErrorTest.kt
@@ -86,12 +86,7 @@ class CustomErrorTest : FunSpec({
                 "ErrorWithStruct",
                 listOf(
                     AbiType.UInt(256),
-                    AbiType.Tuple.struct(
-                        ErrorMsg::class,
-                        AbiType.String,
-                        AbiType.UInt(256),
-                        AbiType.Array(AbiType.Bool),
-                    ),
+                    ErrorMsg.abi,
                 ),
                 emptyList(),
             )

--- a/ethers-abigen/src/main/kotlin/io/ethers/abigen/AbiTypeParameter.kt
+++ b/ethers-abigen/src/main/kotlin/io/ethers/abigen/AbiTypeParameter.kt
@@ -67,12 +67,9 @@ sealed interface AbiTypeParameter {
 
         // this can be raw Tuple, the correct one is created when generating the initializer
         override val abiType: AbiType.Tuple<*> = AbiType.Tuple.raw(fields.map { it.abiType })
-        override val abiTypeInitializer: String
 
-        init {
-            // Reference the StructFactory.abi property instead of redefining the ABI type
-            this.abiTypeInitializer = "${className.simpleName}.abi"
-        }
+        // Reference the StructFactory.abi property instead of redefining the ABI type
+        override val abiTypeInitializer = "${className.simpleName}.abi"
 
         // Generate ABI type initializers for struct fields, using StructFactory.abi references where possible
         private fun getFieldAbiInitializers(currentStruct: ClassName? = null): String {

--- a/ethers-abigen/src/test/kotlin/io/ethers/abigen/cases/StructsTest.kt
+++ b/ethers-abigen/src/test/kotlin/io/ethers/abigen/cases/StructsTest.kt
@@ -1,5 +1,6 @@
 package io.ethers.abigen.cases
 
+import io.ethers.abi.AbiType
 import io.ethers.abi.ContractStruct
 import io.ethers.abi.StructFactory
 import io.ethers.abigen.AbigenCompiler
@@ -8,6 +9,7 @@ import io.ethers.abigen.ClassDescriptor
 import io.ethers.abigen.getDeclaredStructs
 import io.ethers.abigen.nestedClass
 import io.ethers.abigen.parametrizedBy
+import io.ethers.abigen.typedNestedClass
 import io.ethers.core.types.Bytes
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -24,6 +26,44 @@ class StructsTest : FunSpec({
 
         test("all structs should have a factory") {
             classes.all { it.companionObjectInstance is StructFactory<*> } shouldBe true
+        }
+
+        test("all factories have correct abi signature") {
+            val factories = classes.map { it.companionObjectInstance as StructFactory<*> }
+            factories.map { it.abi } shouldContainExactlyInAnyOrder listOf(
+                AbiType.Tuple.struct(
+                    clazz.typedNestedClass("Simple"),
+                    AbiType.Bool,
+                    AbiType.Bytes,
+                ),
+                AbiType.Tuple.struct(
+                    clazz.typedNestedClass("Complex"),
+                    AbiType.Array(AbiType.Array(AbiType.Array(AbiType.UInt(256)))),
+                    AbiType.FixedArray(3, AbiType.String),
+                ),
+                AbiType.Tuple.struct(
+                    clazz.typedNestedClass("Nested"),
+                    AbiType.String,
+                    AbiType.Tuple.struct(
+                        clazz.typedNestedClass("Simple"),
+                        AbiType.Bool,
+                        AbiType.Bytes,
+                    ),
+                    AbiType.Tuple.struct(
+                        clazz.typedNestedClass("Complex"),
+                        AbiType.Array(AbiType.Array(AbiType.Array(AbiType.UInt(256)))),
+                        AbiType.FixedArray(3, AbiType.String),
+                    ),
+                ),
+                AbiType.Tuple.struct(
+                    clazz.typedNestedClass("classStruct"),
+                    AbiType.String,
+                ),
+                AbiType.Tuple.struct(
+                    clazz.typedNestedClass("packageStruct"),
+                    AbiType.String,
+                ),
+            )
         }
 
         test("nested struct encodes/decodes correctly") {


### PR DESCRIPTION
## Summary
This PR optimizes struct ABI handling by adding typed ABI definitions to StructFactory and eliminating duplicate ABI type definitions throughout the codebase.

### Key Changes

**1. Enhanced StructFactory Interface**
- Added `val abi: AbiType.Tuple<T>` to `StructFactory<T>` interface
- Uses actual struct class as generic type parameter for better type safety

**2. Optimized Code Generation**
- Updated `AbiTypeParameter.Struct` to reference `StructName.abi` instead of redefining ABI types
- Added circular dependency protection for nested struct definitions
- Generated structs now use `AbiType.Tuple<StructClassName>` for proper type inference

**3. Reduced Code Duplication**
- Updated Multicall3 function definitions to use struct ABI references
- Eliminated 11+ duplicate ABI type definitions across the codebase
- Established single source of truth for each struct's ABI definition

### Benefits
- **DRY Principle**: Eliminates duplicate ABI type definitions when structs are used in multiple places
- **Type Safety**: Proper generic typing with `AbiType.Tuple<StructType>` instead of wildcards
- **Maintainability**: Changes to struct ABI definitions only need to be made in one place
- **Performance**: Reduces generated code size and compilation overhead
- **Consistency**: All references to a struct now point to the same canonical definition

### Example
**Before:**
```kotlin
// Function parameter definition
AbiType.Array(AbiType.Tuple.struct(Call3::class, AbiType.Address, AbiType.Bool, AbiType.Bytes))

// Event parameter definition  
AbiType.Tuple.struct(Call3::class, AbiType.Address, AbiType.Bool, AbiType.Bytes)
```

**After:**
```kotlin
// Function parameter definition
AbiType.Array(Call3.abi)

// Event parameter definition
Call3.abi
```

## Test plan
- [x] All existing tests pass
- [x] Project builds successfully 
- [x] Code generation works correctly with proper type inference
- [x] Circular dependency handling works for nested structs

🤖 Generated with [Claude Code](https://claude.ai/code)