### PR TITLE
refactor: abstract ws/http transports

### DIFF
--- a/ethers-providers/src/main/kotlin/io/ethers/providers/HttpTransport.kt
+++ b/ethers-providers/src/main/kotlin/io/ethers/providers/HttpTransport.kt
@@ -11,9 +11,18 @@ interface HttpTransport {
      * Execute an HTTP POST request with the given body.
      *
      * @param body The request body bytes
-     * @return A future that completes with the result
+     * @param callback Invoked with the result when the request completes
      */
-    fun execute(body: ByteArray): CompletableFuture<HttpResult>
+    fun execute(body: ByteArray, callback: (HttpResult) -> Unit)
+}
+
+/**
+ * Execute an HTTP POST request and return the result as a [CompletableFuture].
+ */
+fun HttpTransport.executeAsync(body: ByteArray): CompletableFuture<HttpResult> {
+    val future = CompletableFuture<HttpResult>()
+    execute(body) { result -> future.complete(result) }
+    return future
 }
 
 /**

--- a/ethers-providers/src/main/kotlin/io/ethers/providers/HttpTransport.kt
+++ b/ethers-providers/src/main/kotlin/io/ethers/providers/HttpTransport.kt
@@ -1,0 +1,60 @@
+package io.ethers.providers
+
+import java.io.InputStream
+
+/**
+ * HTTP transport abstraction. The transport is pre-configured with URL and headers.
+ */
+interface HttpTransport {
+    /**
+     * Execute an HTTP POST request with the given body.
+     *
+     * @param body The request body bytes
+     * @param callback Callback for handling the response
+     */
+    fun execute(body: ByteArray, callback: HttpCallback)
+}
+
+/**
+ * Callback interface for HTTP responses.
+ */
+interface HttpCallback {
+    /**
+     * Called when a response is received (may be successful or not).
+     *
+     * @param response The HTTP response
+     */
+    fun onResponse(response: HttpResponse)
+
+    /**
+     * Called when the request fails (network error, etc.).
+     *
+     * @param error The exception that occurred
+     */
+    fun onFailure(error: Throwable)
+}
+
+/**
+ * HTTP response abstraction.
+ */
+interface HttpResponse : AutoCloseable {
+    /**
+     * Whether the response was successful (2xx status code).
+     */
+    val isSuccessful: Boolean
+
+    /**
+     * The HTTP status code.
+     */
+    val code: Int
+
+    /**
+     * The HTTP status message.
+     */
+    val message: String
+
+    /**
+     * The response body as an input stream.
+     */
+    val body: InputStream
+}

--- a/ethers-providers/src/main/kotlin/io/ethers/providers/OkHttpTransport.kt
+++ b/ethers-providers/src/main/kotlin/io/ethers/providers/OkHttpTransport.kt
@@ -1,0 +1,69 @@
+package io.ethers.providers
+
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import java.io.IOException
+import java.io.InputStream
+
+/**
+ * OkHttp-based implementation of [HttpTransport].
+ */
+class OkHttpTransport(
+    url: String,
+    headers: Map<String, String>,
+    private val client: OkHttpClient,
+) : HttpTransport {
+
+    private val httpUrl = url.toHttpUrl()
+    private val requestHeaders = Headers.Builder().apply {
+        headers.forEach { (k, v) -> add(k, v) }
+    }.build()
+
+    override fun execute(body: ByteArray, callback: HttpCallback) {
+        val requestBody = body.toRequestBody(JSON_MEDIA_TYPE)
+        val request = Request.Builder()
+            .url(httpUrl)
+            .headers(requestHeaders)
+            .post(requestBody)
+            .build()
+
+        client.newCall(request).enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                callback.onFailure(e)
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                callback.onResponse(OkHttpResponse(response))
+            }
+        })
+    }
+
+    private class OkHttpResponse(private val response: Response) : HttpResponse {
+        override val isSuccessful: Boolean
+            get() = response.isSuccessful
+
+        override val code: Int
+            get() = response.code
+
+        override val message: String
+            get() = response.message
+
+        override val body: InputStream
+            get() = response.body.byteStream()
+
+        override fun close() {
+            response.close()
+        }
+    }
+
+    companion object {
+        private val JSON_MEDIA_TYPE = "application/json".toMediaType()
+    }
+}

--- a/ethers-providers/src/main/kotlin/io/ethers/providers/OkHttpWebSocketTransport.kt
+++ b/ethers-providers/src/main/kotlin/io/ethers/providers/OkHttpWebSocketTransport.kt
@@ -1,0 +1,70 @@
+package io.ethers.providers
+
+import okhttp3.Headers
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okio.ByteString
+import java.io.IOException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import okhttp3.WebSocketListener as OkHttpWebSocketListener
+
+/**
+ * OkHttp-based implementation of [WebSocketTransport].
+ */
+class OkHttpWebSocketTransport(
+    private val url: String,
+    private val headers: Map<String, String>,
+    private val client: OkHttpClient,
+) : WebSocketTransport {
+
+    override val connectTimeout: Duration
+        get() = client.connectTimeoutMillis.toLong().milliseconds
+
+    override val readTimeout: Duration
+        get() = client.readTimeoutMillis.toLong().milliseconds
+
+    override fun connect(listener: WebSocketListener): WebSocketConnection {
+        val requestHeaders = Headers.Builder().apply {
+            headers.forEach { (key, value) -> add(key, value) }
+        }.build()
+        val wsRequest = Request.Builder().url(url).headers(requestHeaders).build()
+
+        val okHttpListener = object : OkHttpWebSocketListener() {
+            override fun onOpen(webSocket: WebSocket, response: Response) {
+                listener.onOpen()
+            }
+
+            override fun onMessage(webSocket: WebSocket, text: String) {
+                listener.onMessage(text)
+            }
+
+            override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
+                // will trigger "onFailure" callback
+                throw IOException("Binary messages are not supported")
+            }
+
+            override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                listener.onClosing(code, reason)
+            }
+
+            override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                listener.onClosed(code, reason)
+            }
+
+            override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                listener.onFailure(t)
+            }
+        }
+
+        val webSocket = client.newWebSocket(wsRequest, okHttpListener)
+        return OkHttpWebSocketConnection(webSocket)
+    }
+
+    private class OkHttpWebSocketConnection(private val webSocket: WebSocket) : WebSocketConnection {
+        override fun send(text: String): Boolean = webSocket.send(text)
+        override fun close(code: Int, reason: String): Boolean = webSocket.close(code, reason)
+    }
+}

--- a/ethers-providers/src/main/kotlin/io/ethers/providers/WebSocketTransport.kt
+++ b/ethers-providers/src/main/kotlin/io/ethers/providers/WebSocketTransport.kt
@@ -1,0 +1,91 @@
+package io.ethers.providers
+
+import kotlin.time.Duration
+
+/**
+ * WebSocket transport abstraction. The transport is pre-configured with URL and settings.
+ * Calling [connect] multiple times on the same instance creates new connections (for reconnection).
+ */
+interface WebSocketTransport {
+    /**
+     * Timeout for establishing a connection.
+     */
+    val connectTimeout: Duration
+
+    /**
+     * Timeout for read operations (used for request expiration).
+     */
+    val readTimeout: Duration
+
+    /**
+     * Connect to the WebSocket server.
+     *
+     * @param listener Callback interface for connection events
+     * @return A handle to the active connection
+     */
+    fun connect(listener: WebSocketListener): WebSocketConnection
+}
+
+/**
+ * Handle to an active WebSocket connection.
+ * Allows sending messages and closing the connection.
+ */
+interface WebSocketConnection {
+    /**
+     * Send a text message over the WebSocket.
+     *
+     * @param text The message to send
+     * @return true if the message was enqueued successfully, false otherwise
+     */
+    fun send(text: String): Boolean
+
+    /**
+     * Initiate graceful close of the connection.
+     *
+     * @param code The WebSocket close code
+     * @param reason Human-readable close reason
+     * @return true if close was initiated, false if already closing/closed
+     */
+    fun close(code: Int, reason: String): Boolean
+}
+
+/**
+ * Callback interface for WebSocket events.
+ * All callbacks are invoked on the WebSocket's internal thread.
+ */
+interface WebSocketListener {
+    /**
+     * Called when the connection is successfully opened.
+     */
+    fun onOpen()
+
+    /**
+     * Called when a text message is received.
+     *
+     * @param text The received message
+     */
+    fun onMessage(text: String)
+
+    /**
+     * Called when the remote side initiates a close.
+     *
+     * @param code The WebSocket close code
+     * @param reason Human-readable close reason
+     */
+    fun onClosing(code: Int, reason: String)
+
+    /**
+     * Called when the connection is fully closed.
+     *
+     * @param code The WebSocket close code
+     * @param reason Human-readable close reason
+     */
+    fun onClosed(code: Int, reason: String)
+
+    /**
+     * Called when an error occurs.
+     *
+     * @param error The exception that occurred
+     */
+    fun onFailure(error: Throwable)
+}


### PR DESCRIPTION
## Description

This PR extracts transport operations from both WsClient and HttpClient into pluggable interfaces, allowing different implementations while keeping JSON-RPC processing logic in the client classes. This enables easier testing and future support for alternative transport libraries.

## Solution

Created abstract transport interfaces and OkHttp implementations for both WebSocket and HTTP transports.

### WebSocket Transport
- `WebSocketTransport` interface for connection management
- `WebSocketConnection` interface for sending/closing
- `WebSocketListener` interface for event callbacks
- `OkHttpWebSocketTransport` as the default implementation

### HTTP Transport
- `HttpTransport` interface for executing requests
- `HttpCallback` interface for async response handling
- `HttpResponse` interface for response data
- `OkHttpTransport` as the default implementation

All existing constructors are preserved for backward compatibility.