### PR TITLE
refactor: change JsonRpcClient to use callback-based API

### DIFF
--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/HttpClient.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/HttpClient.kt
@@ -31,7 +31,6 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
-import java.util.concurrent.CompletableFuture
 
 /**
  * [JsonRpcClient] implementation via HTTP transport. Supports both single and batch requests. Subscriptions are not
@@ -56,14 +55,13 @@ class HttpClient(
     private val requestId = atomic(1L)
     private val headers = Headers.Builder().apply { headers.forEach { (k, v) -> add(k, v) } }.build()
 
-    override fun requestBatch(batch: BatchRpcRequest): CompletableFuture<Boolean> {
+    override fun requestBatch(batch: BatchRpcRequest, callback: ResultCallback<Boolean>) {
         batch.markAsSent()
 
         if (batch.isEmpty) {
-            return CompletableFuture.completedFuture(true)
+            callback.complete(true)
+            return
         }
-
-        val ret = CompletableFuture<Boolean>()
 
         val (body, requestIndexPerId) = batch.toRequestBody()
         val call = client.newCall(Request.Builder().url(httpUrl).headers(headers).post(body).build())
@@ -72,13 +70,12 @@ class HttpClient(
             override fun onFailure(call: Call, e: IOException) {
                 LOG.err(e) { "Error sending batch request" }
 
-                // complete all requests and the batch future
                 val response = getResponseFromException(e)
-                for (i in batch.responses.indices) {
-                    batch.responses[i].complete(response)
+                for (i in batch.callbacks.indices) {
+                    batch.callbacks[i].complete(response)
                 }
 
-                ret.complete(false)
+                callback.complete(false)
             }
 
             override fun onResponse(call: Call, response: Response) {
@@ -86,7 +83,6 @@ class HttpClient(
                     try {
                         var stream = it.body.byteStream()
                         LOG.trc {
-                            // reading from the response body consumes it, so we need to create a new stream
                             val arr = stream.readBytes()
                             stream = ByteArrayInputStream(arr)
                             "Batch response: ${String(arr)}".removeSuffix("\n")
@@ -95,7 +91,6 @@ class HttpClient(
                         if (!it.isSuccessful) {
                             val bytes = stream.readBytes()
 
-                            // first, try to decode a JSON response
                             try {
                                 ByteArrayInputStream(bytes).useJsonParser {
                                     val parser = this
@@ -107,17 +102,15 @@ class HttpClient(
                                             batch.requests[index].resultDecoder
                                         }
 
-                                        batch.responses[index].complete(result)
+                                        batch.callbacks[index].complete(result)
                                     }
                                 }
 
-                                ret.complete(true)
+                                callback.complete(true)
                                 return
                             } catch (_: Exception) {
                             }
 
-                            // second, if decoding fails, return the response as a message and complete all requests
-                            // including the batch future
                             val message = "HTTP ${it.code}: ${it.message}"
                             val data = jsonMapper.valueToTree<JsonNode>(String(bytes))
                             val error = RpcError(RpcError.CODE_CALL_FAILED, message, data)
@@ -125,11 +118,11 @@ class HttpClient(
 
                             LOG.err { "Batch request failed: $error" }
 
-                            for (i in batch.responses.indices) {
-                                batch.responses[i].complete(failure)
+                            for (i in batch.callbacks.indices) {
+                                batch.callbacks[i].complete(failure)
                             }
 
-                            ret.complete(false)
+                            callback.complete(false)
                             return
                         }
 
@@ -143,37 +136,33 @@ class HttpClient(
                                     batch.requests[index].resultDecoder
                                 }
 
-                                batch.responses[index].complete(result)
+                                batch.callbacks[index].complete(result)
                             }
                         }
 
-                        ret.complete(true)
+                        callback.complete(true)
                     } catch (e: Exception) {
                         LOG.err(e) { "Error processing batch response" }
                         val rpcResponse = getResponseFromException(e)
 
-                        // complete all requests and the batch future
-                        for (i in batch.responses.indices) {
-                            batch.responses[i].complete(rpcResponse)
+                        for (i in batch.callbacks.indices) {
+                            batch.callbacks[i].complete(rpcResponse)
                         }
 
-                        ret.complete(false)
+                        callback.complete(false)
                         return
                     }
                 }
             }
         })
-
-        return ret
     }
 
     override fun <T> request(
         method: String,
         params: Array<*>,
         resultDecoder: (JsonParser) -> T,
-    ): CompletableFuture<Result<T, RpcError>> {
-        val ret = CompletableFuture<Result<T, RpcError>>()
-
+        callback: ResultCallback<Result<T, RpcError>>,
+    ) {
         val body = createJsonRpcRequestBody(method, params)
         val call = client.newCall(Request.Builder().url(httpUrl).headers(headers).post(body).build())
 
@@ -181,7 +170,7 @@ class HttpClient(
             override fun onFailure(call: Call, e: IOException) {
                 LOG.err(e) { "Error sending request for method=$method, params=${params.contentToString()}" }
 
-                ret.complete(getResponseFromException(e))
+                callback.complete(getResponseFromException(e))
             }
 
             override fun onResponse(call: Call, response: Response) {
@@ -189,7 +178,6 @@ class HttpClient(
                     try {
                         var stream = it.body.byteStream()
                         LOG.trc {
-                            // reading from the response body consumes it, so we need to create a new stream
                             val arr = stream.readBytes()
                             stream = ByteArrayInputStream(arr)
                             "Response: ${String(arr)}".removeSuffix("\n")
@@ -198,35 +186,31 @@ class HttpClient(
                         if (!it.isSuccessful) {
                             val bytes = stream.readBytes()
 
-                            // first, try to decode a JSON response
                             try {
-                                ret.complete(ByteArrayInputStream(bytes).decodeResult(resultDecoder))
+                                callback.complete(ByteArrayInputStream(bytes).decodeResult(resultDecoder))
                                 return
                             } catch (_: Exception) {
                             }
 
-                            // second, if decoding fails, return the response as a message
                             val message = "HTTP ${it.code}: ${it.message}"
                             val data = jsonMapper.valueToTree<JsonNode>(String(bytes))
                             val error = RpcError(RpcError.CODE_CALL_FAILED, message, data)
                             LOG.err { "Call failed for method=$method, params=${params.contentToString()}: $error" }
 
-                            ret.complete(failure(error))
+                            callback.complete(failure(error))
                             return
                         }
 
-                        ret.complete(stream.decodeResult(resultDecoder))
+                        callback.complete(stream.decodeResult(resultDecoder))
                     } catch (e: Exception) {
                         LOG.err(e) { "Error processing response for method=$method, params=${params.contentToString()}" }
 
-                        ret.complete(getResponseFromException(e))
+                        callback.complete(getResponseFromException(e))
                         return
                     }
                 }
             }
         })
-
-        return ret
     }
 
     private fun <T> InputStream.decodeResult(decoder: (JsonParser) -> T): Result<T, RpcError> {
@@ -278,8 +262,9 @@ class HttpClient(
     override fun <T : Any> subscribe(
         params: Array<*>,
         resultDecoder: (JsonParser) -> T,
-    ): CompletableFuture<Result<ChannelReceiver<T>, RpcError>> {
-        return CompletableFuture.completedFuture(ERROR_SUBSCRIPTION_UNSUPPORTED)
+        callback: ResultCallback<Result<ChannelReceiver<T>, RpcError>>,
+    ) {
+        callback.complete(ERROR_SUBSCRIPTION_UNSUPPORTED)
     }
 
     override fun close() {

--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/JsonRpcClient.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/JsonRpcClient.kt
@@ -14,8 +14,11 @@ import io.ethers.core.Result
 import io.ethers.core.forEachObjectField
 import io.ethers.providers.types.BatchRpcRequest
 import okhttp3.OkHttpClient
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
+
+fun interface ResultCallback<T> {
+    fun complete(result: T)
+}
 
 interface JsonRpcClient : AutoCloseable {
     /**
@@ -24,12 +27,16 @@ interface JsonRpcClient : AutoCloseable {
      * @param method RPC function name
      * @param params RPC function parameters
      * @param resultType class into which JSON result is converted
+     * @param callback callback to receive the result
      */
     fun <T> request(
         method: String,
         params: Array<*>,
         resultType: Class<T>,
-    ) = request(method, params) { p -> p.readValueAs(resultType) }
+        callback: ResultCallback<Result<T, RpcError>>,
+    ) {
+        request(method, params, { p -> p.readValueAs(resultType) }, callback)
+    }
 
     /**
      * Asynchronously execute RPC request.
@@ -37,29 +44,33 @@ interface JsonRpcClient : AutoCloseable {
      * @param method RPC function name
      * @param params RPC function parameters
      * @param resultDecoder function to convert JSON result into object return [T].
+     * @param callback callback to receive the result
      */
     fun <T> request(
         method: String,
         params: Array<*>,
         resultDecoder: (JsonParser) -> T,
-    ): CompletableFuture<Result<T, RpcError>>
+        callback: ResultCallback<Result<T, RpcError>>,
+    )
 
     /**
      * Asynchronously execute [batch] of RPC requests.
      */
-    fun requestBatch(batch: BatchRpcRequest): CompletableFuture<Boolean>
+    fun requestBatch(batch: BatchRpcRequest, callback: ResultCallback<Boolean>)
 
     /**
      * Subscribe to a stream via `eth_subscribe`, if the client supports it.
      *
      * @param params the subscription parameters
      * @param resultType class into which JSON result is converted
+     * @param callback callback to receive the result
      */
     fun <T : Any> subscribe(
         params: Array<*>,
         resultType: Class<T>,
-    ): CompletableFuture<Result<ChannelReceiver<T>, RpcError>> {
-        return subscribe(params) { p -> p.readValueAs(resultType) }
+        callback: ResultCallback<Result<ChannelReceiver<T>, RpcError>>,
+    ) {
+        subscribe(params, { p -> p.readValueAs(resultType) }, callback)
     }
 
     /**
@@ -67,11 +78,13 @@ interface JsonRpcClient : AutoCloseable {
      *
      * @param params the subscription parameters
      * @param resultDecoder function to convert JSON result into return object [T]
+     * @param callback callback to receive the result
      */
     fun <T : Any> subscribe(
         params: Array<*>,
         resultDecoder: (JsonParser) -> T,
-    ): CompletableFuture<Result<ChannelReceiver<T>, RpcError>>
+        callback: ResultCallback<Result<ChannelReceiver<T>, RpcError>>,
+    )
 }
 
 /**

--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/WsClient.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/WsClient.kt
@@ -598,10 +598,10 @@ class WsClient(
                 else -> failure(error!!)
             }
 
-            batch.request.responses[responseIndex].complete(response)
+            batch.request.callbacks[responseIndex].complete(response)
         }
 
-        batch?.future?.complete(true)
+        batch?.callback?.complete(true)
     }
 
     private fun getBatchFromRequestId(requestId: Long): Pair<CompletableBatchRequest, HashMap<Long, Int>>? {
@@ -656,7 +656,7 @@ class WsClient(
 
         LOG.trc { "Handled response for request $id: $response" }
 
-        request.future.complete(response)
+        request.callback.complete(response)
     }
 
     private fun <T : Any> handleSubscriptionResponse(
@@ -666,14 +666,13 @@ class WsClient(
         error: RpcError?,
     ) {
         if (error != null) {
-            request.future.complete(failure(error))
+            request.callback.complete(failure(error))
         } else {
             val subscription = Subscription(
                 serverId = resultParser.text,
                 params = request.params,
                 resultDecoder = request.resultDecoder,
                 stream = QueueChannel.spscUnbounded {
-                    // requestId is constant even across re-subscriptions. Just queue for processor thread.
                     unsubscribeQueue.add(id)
                     eventLock.withLock {
                         newEventCondition.signalAll()
@@ -684,7 +683,7 @@ class WsClient(
             requestIdToSubscription[id] = subscription
             serverIdToSubscription[subscription.serverId] = subscription
 
-            request.future.complete(success(subscription.stream))
+            request.callback.complete(success(subscription.stream))
         }
 
         LOG.trc { "Handled response for subscription request $id" }
@@ -758,49 +757,49 @@ class WsClient(
         client.connectionPool.evictAll()
     }
 
-    override fun requestBatch(batch: BatchRpcRequest): CompletableFuture<Boolean> {
+    override fun requestBatch(batch: BatchRpcRequest, callback: ResultCallback<Boolean>) {
         if (batch.isEmpty) {
             batch.markAsSent()
-            return CompletableFuture.completedFuture(true)
+            callback.complete(true)
+            return
         }
 
-        val request = CompletableBatchRequest(batch, CompletableFuture())
+        val request = CompletableBatchRequest(batch, ResultCallback { callback.complete(it) })
 
         batchRequestQueue.add(request)
         eventLock.withLock { newEventCondition.signalAll() }
-        return request.future
     }
 
     override fun <T> request(
         method: String,
         params: Array<*>,
         resultDecoder: (JsonParser) -> T,
-    ): CompletableFuture<Result<T, RpcError>> {
+        callback: ResultCallback<Result<T, RpcError>>,
+    ) {
         val request = CompletableRequest(
             method,
             params,
             resultDecoder,
-            CompletableFuture(),
+            callback,
         )
 
         requestQueue.add(request)
         eventLock.withLock { newEventCondition.signalAll() }
-        return request.future
     }
 
     override fun <T : Any> subscribe(
         params: Array<*>,
         resultDecoder: (JsonParser) -> T,
-    ): CompletableFuture<Result<ChannelReceiver<T>, RpcError>> {
+        callback: ResultCallback<Result<ChannelReceiver<T>, RpcError>>,
+    ) {
         val request = CompletableSubscriptionRequest(
             params,
             resultDecoder,
-            CompletableFuture(),
+            callback,
         )
 
         subscriptionQueue.add(request)
         eventLock.withLock { newEventCondition.signalAll() }
-        return request.future
     }
 
     private abstract class ExpiringRequest {
@@ -822,34 +821,33 @@ class WsClient(
         val method: String,
         val params: Array<*>,
         val resultDecoder: (JsonParser) -> T,
-        val future: CompletableFuture<Result<T, RpcError>>,
+        val callback: ResultCallback<Result<T, RpcError>>,
     ) : ExpiringRequest() {
         override fun expireRequest() {
-            future.complete(HttpClient.ERROR_CALL_TIMEOUT)
+            callback.complete(HttpClient.ERROR_CALL_TIMEOUT)
         }
     }
 
     private data class CompletableBatchRequest(
         val request: BatchRpcRequest,
-        val future: CompletableFuture<Boolean>,
+        val callback: ResultCallback<Boolean>,
     ) : ExpiringRequest() {
         override fun expireRequest() {
-            for (i in request.responses.indices) {
-                val response = request.responses[i]
-                response.complete(HttpClient.ERROR_CALL_TIMEOUT)
+            for (i in request.callbacks.indices) {
+                request.callbacks[i].complete(HttpClient.ERROR_CALL_TIMEOUT)
             }
 
-            future.complete(false)
+            callback.complete(false)
         }
     }
 
     private class CompletableSubscriptionRequest<T : Any>(
         val params: Array<*>,
         val resultDecoder: (JsonParser) -> T,
-        val future: CompletableFuture<Result<ChannelReceiver<T>, RpcError>>,
+        val callback: ResultCallback<Result<ChannelReceiver<T>, RpcError>>,
     ) : ExpiringRequest() {
         override fun expireRequest() {
-            future.complete(HttpClient.ERROR_CALL_TIMEOUT)
+            callback.complete(HttpClient.ERROR_CALL_TIMEOUT)
         }
     }
 

--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/types/BatchRpcRequest.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/types/BatchRpcRequest.kt
@@ -4,6 +4,7 @@ package io.ethers.providers.types
 
 import io.ethers.core.Result
 import io.ethers.providers.JsonRpcClient
+import io.ethers.providers.ResultCallback
 import io.ethers.providers.RpcError
 import kotlinx.atomicfu.atomic
 import java.util.concurrent.CompletableFuture
@@ -18,13 +19,16 @@ class BatchRpcRequest @JvmOverloads constructor(defaultSize: Int = 10) {
     private val _requests = ArrayList<RpcCall<*>>(defaultSize)
     internal val requests: List<RpcCall<*>> get() = _requests
 
+    private val _callbacks = ArrayList<ResultCallback<Result<*, RpcError>>>(defaultSize)
+    internal val callbacks: List<ResultCallback<Result<*, RpcError>>> get() = _callbacks
+
     private val _responses = ArrayList<CompletableFuture<Result<*, RpcError>>>(defaultSize)
     internal val responses: List<CompletableFuture<Result<*, RpcError>>> get() = _responses
 
     private var client: JsonRpcClient? = null
 
     /**
-     * Returns true if this batch has no requests.
+     * Returns true if this this batch has no requests.
      * */
     val isEmpty: Boolean get() = requests.isEmpty()
 
@@ -42,8 +46,13 @@ class BatchRpcRequest @JvmOverloads constructor(defaultSize: Int = 10) {
         }
 
         val future = ConditionalCompletableFuture<Result<T, RpcError>> { batchSent.value }
+        val callback = ResultCallback<Result<T, RpcError>> { result ->
+            @Suppress("UNCHECKED_CAST")
+            (future as CompletableFuture<Result<T, RpcError>>).complete(result)
+        }
 
         _requests.add(request)
+        _callbacks.add(callback as ResultCallback<Result<*, RpcError>>)
         _responses.add(future as CompletableFuture<Result<*, RpcError>>)
 
         return future
@@ -64,7 +73,11 @@ class BatchRpcRequest @JvmOverloads constructor(defaultSize: Int = 10) {
             return CompletableFuture.completedFuture(false)
         }
 
-        return client!!.requestBatch(this)
+        val future = CompletableFuture<Boolean>()
+        client!!.requestBatch(this) { result ->
+            future.complete(result)
+        }
+        return future
     }
 
     internal fun markAsSent() {

--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/types/RpcRequest.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/types/RpcRequest.kt
@@ -5,6 +5,7 @@ import io.ethers.core.Result
 import io.ethers.core.Result.Consumer
 import io.ethers.providers.AsyncExecutor
 import io.ethers.providers.JsonRpcClient
+import io.ethers.providers.ResultCallback
 import io.ethers.providers.RpcError
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
@@ -106,7 +107,13 @@ class RpcCall<T>(
     ) : this(client, method, params, { p -> p.readValueAs(resultType) })
 
     override fun sendAwait(): Result<T, RpcError> = sendAsync().join()
-    override fun sendAsync(): CompletableFuture<Result<T, RpcError>> = client.request(method, params, resultDecoder)
+    override fun sendAsync(): CompletableFuture<Result<T, RpcError>> {
+        val future = CompletableFuture<Result<T, RpcError>>()
+        client.request(method, params, resultDecoder) { result ->
+            future.complete(result)
+        }
+        return future
+    }
     override fun batch(batch: BatchRpcRequest): CompletableFuture<Result<T, RpcError>> = batch.addRpcCall(this)
 
     override fun toString(): String {

--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/types/RpcSubscribe.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/types/RpcSubscribe.kt
@@ -5,6 +5,7 @@ import io.channels.core.ChannelReceiver
 import io.ethers.core.Result
 import io.ethers.core.Result.Consumer
 import io.ethers.providers.JsonRpcClient
+import io.ethers.providers.ResultCallback
 import io.ethers.providers.RpcError
 import java.util.concurrent.CompletableFuture
 
@@ -114,7 +115,11 @@ class RpcSubscribeCall<T : Any>(
 
     override fun sendAwait(): Result<ChannelReceiver<T>, RpcError> = sendAsync().join()
     override fun sendAsync(): CompletableFuture<Result<ChannelReceiver<T>, RpcError>> {
-        return client.subscribe(params, resultDecoder)
+        val future = CompletableFuture<Result<ChannelReceiver<T>, RpcError>>()
+        client.subscribe(params, resultDecoder) { result ->
+            future.complete(result)
+        }
+        return future
     }
 
     override fun toString(): String {

--- a/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/HttpClientTest.kt
+++ b/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/HttpClientTest.kt
@@ -1,7 +1,9 @@
 package io.ethers.providers
 
 import com.fasterxml.jackson.core.JsonParser
+import io.channels.core.ChannelReceiver
 import io.ethers.core.Jackson
+import io.ethers.core.Result
 import io.ethers.core.isFailure
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.funSpec
@@ -11,6 +13,7 @@ import io.kotest.matchers.string.shouldContain
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import org.intellij.lang.annotations.Language
+import java.util.concurrent.CompletableFuture
 
 /**
  * HttpClient tests demonstrating extraction of common JsonRpcClient tests into a factory pattern.
@@ -49,7 +52,9 @@ private fun httpSpecificTests() = funSpec {
         test("HTTP error with JSON response") {
             server.enqueue(createMockResponse(RPC_ERROR_RESPONSE, 500))
 
-            val result = client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder).get()
+            val resultFuture = CompletableFuture<Result<String, RpcError>>()
+            client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder) { resultFuture.complete(it) }
+            val result = resultFuture.get()
 
             result.isFailure() shouldBe true
             val error = result.unwrapError()
@@ -60,7 +65,9 @@ private fun httpSpecificTests() = funSpec {
         test("HTTP error with non-JSON response") {
             server.enqueue(MockResponse().setResponseCode(500).setBody("Internal Server Error"))
 
-            val result = client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder).get()
+            val resultFuture = CompletableFuture<Result<String, RpcError>>()
+            client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder) { resultFuture.complete(it) }
+            val result = resultFuture.get()
 
             result.isFailure() shouldBe true
             val error = result.unwrapError()
@@ -71,7 +78,9 @@ private fun httpSpecificTests() = funSpec {
         test("empty response body") {
             server.enqueue(MockResponse().setResponseCode(200).setBody(""))
 
-            val result = client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder).get()
+            val resultFuture = CompletableFuture<Result<String, RpcError>>()
+            client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder) { resultFuture.complete(it) }
+            val result = resultFuture.get()
 
             result.isFailure() shouldBe true
             val error = result.unwrapError()
@@ -84,7 +93,9 @@ private fun httpSpecificTests() = funSpec {
             val headersMap = mapOf("Authorization" to "Bearer token123", "Custom-Header" to "value")
             val clientWithHeaders = HttpClient(server.url, OkHttpClient(), headersMap)
 
-            clientWithHeaders.request("eth_blockNumber", emptyArray<Any>(), stringDecoder).get()
+            val reqFuture = CompletableFuture<Result<String, RpcError>>()
+            clientWithHeaders.request("eth_blockNumber", emptyArray<Any>(), stringDecoder) { reqFuture.complete(it) }
+            reqFuture.get()
 
             val request = server.takeRequest()
             request.getHeader("Authorization") shouldBe "Bearer token123"
@@ -94,7 +105,9 @@ private fun httpSpecificTests() = funSpec {
         test("content-Type header is set correctly") {
             server.enqueue(createMockResponse(SUCCESSFUL_RESPONSE))
 
-            client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder).get()
+            val reqFuture = CompletableFuture<Result<String, RpcError>>()
+            client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder) { reqFuture.complete(it) }
+            reqFuture.get()
 
             val request = server.takeRequest()
             request.getHeader("Content-Type") shouldBe "application/json"
@@ -104,8 +117,12 @@ private fun httpSpecificTests() = funSpec {
             server.enqueue(createMockResponse(SUCCESSFUL_RESPONSE))
             server.enqueue(createMockResponse(SUCCESSFUL_RESPONSE))
 
-            client.request("method1", emptyArray<Any>(), stringDecoder).get()
-            client.request("method2", emptyArray<Any>(), stringDecoder).get()
+            val resultFuture1 = CompletableFuture<Result<String, RpcError>>()
+            client.request("method1", emptyArray<Any>(), stringDecoder) { resultFuture1.complete(it) }
+            resultFuture1.get()
+            val resultFuture2 = CompletableFuture<Result<String, RpcError>>()
+            client.request("method2", emptyArray<Any>(), stringDecoder) { resultFuture2.complete(it) }
+            resultFuture2.get()
 
             val request1 = server.takeRequest()
             val request2 = server.takeRequest()
@@ -120,7 +137,9 @@ private fun httpSpecificTests() = funSpec {
     context("Subscription tests") {
         test("subscription is not supported") {
             val httpClient = HttpClient("http://localhost:8545", OkHttpClient())
-            val result = httpClient.subscribe(arrayOf("newHeads"), stringDecoder).get()
+            val resultFuture = CompletableFuture<Result<ChannelReceiver<String>, RpcError>>()
+            httpClient.subscribe(arrayOf("newHeads"), stringDecoder) { resultFuture.complete(it) }
+            val result = resultFuture.get()
 
             result.isFailure() shouldBe true
             val error = result.unwrapError()

--- a/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/JsonRpcTestFactory.kt
+++ b/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/JsonRpcTestFactory.kt
@@ -1,6 +1,7 @@
 package io.ethers.providers
 
 import com.fasterxml.jackson.core.JsonParser
+import io.ethers.core.Result
 import io.ethers.core.isFailure
 import io.ethers.core.isSuccess
 import io.ethers.providers.types.BatchRpcRequest
@@ -8,6 +9,7 @@ import io.ethers.providers.types.RpcCall
 import io.kotest.core.spec.style.funSpec
 import io.kotest.matchers.shouldBe
 import org.intellij.lang.annotations.Language
+import java.util.concurrent.CompletableFuture
 
 enum class RpcClientVariant {
     HTTP,
@@ -58,7 +60,9 @@ object JsonRpcTestFactory {
             test("successful request with result") {
                 server.enqueueJson(SUCCESSFUL_RESPONSE)
 
-                val result = client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder).get()
+                val resultFuture = CompletableFuture<Result<String, RpcError>>()
+                client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder) { resultFuture.complete(it) }
+                val result = resultFuture.get()
 
                 result.isSuccess() shouldBe true
                 result.unwrap() shouldBe "0x1234567"
@@ -67,7 +71,9 @@ object JsonRpcTestFactory {
             test("RPC error response") {
                 server.enqueueJson(RPC_ERROR_RESPONSE)
 
-                val result = client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder).get()
+                val resultFuture = CompletableFuture<Result<String, RpcError>>()
+                client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder) { resultFuture.complete(it) }
+                val result = resultFuture.get()
 
                 result.isFailure() shouldBe true
                 val error = result.unwrapError()
@@ -78,7 +84,9 @@ object JsonRpcTestFactory {
             test("invalid JSON response") {
                 server.enqueueJson("invalid json")
 
-                val result = client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder).get()
+                val resultFuture = CompletableFuture<Result<String, RpcError>>()
+                client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder) { resultFuture.complete(it) }
+                val result = resultFuture.get()
 
                 result.isFailure() shouldBe true
                 val error = result.unwrapError()
@@ -88,7 +96,9 @@ object JsonRpcTestFactory {
             test("missing response fields") {
                 server.enqueueJson(RESPONSE_MISSING_FIELDS)
 
-                val result = client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder).get()
+                val resultFuture = CompletableFuture<Result<String, RpcError>>()
+                client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder) { resultFuture.complete(it) }
+                val result = resultFuture.get()
 
                 result.isFailure() shouldBe true
                 val error = result.unwrapError()
@@ -98,7 +108,9 @@ object JsonRpcTestFactory {
             test("request with parameters") {
                 server.enqueueJson(SUCCESSFUL_RESPONSE)
 
-                val result = client.request("eth_getBalance", arrayOf("0x1234", "latest"), stringDecoder).get()
+                val resultFuture = CompletableFuture<Result<String, RpcError>>()
+                client.request("eth_getBalance", arrayOf("0x1234", "latest"), stringDecoder) { resultFuture.complete(it) }
+                val result = resultFuture.get()
 
                 result.isSuccess() shouldBe true
                 result.unwrap() shouldBe "0x1234567"
@@ -108,7 +120,9 @@ object JsonRpcTestFactory {
         context("Common JSON-RPC batch tests") {
             test("empty batch request") {
                 val batch = BatchRpcRequest(0)
-                val batchResult = client.requestBatch(batch).get()
+                val batchResultFuture = CompletableFuture<Boolean>()
+                client.requestBatch(batch) { batchResultFuture.complete(it) }
+                val batchResult = batchResultFuture.get()
                 batchResult shouldBe true // Should complete successfully even with no requests
             }
 
@@ -121,7 +135,9 @@ object JsonRpcTestFactory {
                 batch.addRpcCall(call1)
                 batch.addRpcCall(call2)
 
-                val batchResult = client.requestBatch(batch).get()
+                val batchResultFuture = CompletableFuture<Boolean>()
+                client.requestBatch(batch) { batchResultFuture.complete(it) }
+                val batchResult = batchResultFuture.get()
                 batchResult shouldBe true
 
                 val result1 = batch.responses[0].get()
@@ -144,7 +160,9 @@ object JsonRpcTestFactory {
                 batch.addRpcCall(call2)
                 batch.addRpcCall(call3)
 
-                val batchResult = client.requestBatch(batch).get()
+                val batchResultFuture = CompletableFuture<Boolean>()
+                client.requestBatch(batch) { batchResultFuture.complete(it) }
+                val batchResult = batchResultFuture.get()
                 batchResult shouldBe true
 
                 // Verify responses are correctly matched to requests despite out-of-order response
@@ -160,7 +178,9 @@ object JsonRpcTestFactory {
                 val call1 = RpcCall(client, "eth_blockNumber", emptyArray<Any>(), stringDecoder)
                 batch.addRpcCall(call1)
 
-                val batchResult = client.requestBatch(batch).get()
+                val batchResultFuture = CompletableFuture<Boolean>()
+                client.requestBatch(batch) { batchResultFuture.complete(it) }
+                val batchResult = batchResultFuture.get()
                 batchResult shouldBe false
 
                 batch.responses[0].get().isFailure() shouldBe true
@@ -173,7 +193,9 @@ object JsonRpcTestFactory {
                 val call1 = RpcCall(client, "eth_blockNumber", emptyArray<Any>(), stringDecoder)
                 batch.addRpcCall(call1)
 
-                val batchResult = client.requestBatch(batch).get()
+                val batchResultFuture = CompletableFuture<Boolean>()
+                client.requestBatch(batch) { batchResultFuture.complete(it) }
+                val batchResult = batchResultFuture.get()
                 batchResult shouldBe true
 
                 val result = batch.responses[0].get()
@@ -188,7 +210,9 @@ object JsonRpcTestFactory {
                 val call1 = RpcCall(client, "eth_blockNumber", emptyArray<Any>(), stringDecoder)
                 batch.addRpcCall(call1)
 
-                val batchResult = client.requestBatch(batch).get()
+                val batchResultFuture = CompletableFuture<Boolean>()
+                client.requestBatch(batch) { batchResultFuture.complete(it) }
+                val batchResult = batchResultFuture.get()
                 batchResult shouldBe false
 
                 batch.responses[0].get().isFailure() shouldBe true

--- a/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/WsClientTest.kt
+++ b/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/WsClientTest.kt
@@ -2,13 +2,16 @@ package io.ethers.providers
 
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.JsonNode
+import io.channels.core.ChannelReceiver
 import io.ethers.core.Jackson
+import io.ethers.core.Result
 import io.ethers.core.isSuccess
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import okhttp3.OkHttpClient
 import org.intellij.lang.annotations.Language
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
 /**
@@ -60,7 +63,9 @@ class WsClientTest : FunSpec({
                 Jackson.MAPPER.readTree(parser)
             }
 
-            val subscriptionResult = wsClient.subscribe(params, resultDecoder).get()
+            val subscriptionResultFuture = CompletableFuture<Result<ChannelReceiver<JsonNode>, RpcError>>()
+            wsClient.subscribe(params, resultDecoder) { subscriptionResultFuture.complete(it) }
+            val subscriptionResult = subscriptionResultFuture.get()
             subscriptionResult.isSuccess() shouldBe true
 
             val stream = subscriptionResult.unwrap()
@@ -172,7 +177,9 @@ class WsClientTest : FunSpec({
             val params = arrayOf("newHeads")
             val resultDecoder: (JsonParser) -> JsonNode = { Jackson.MAPPER.readTree(it) }
 
-            val subscriptionResult = wsClient.subscribe(params, resultDecoder).get()
+            val subscriptionResultFuture = CompletableFuture<Result<ChannelReceiver<JsonNode>, RpcError>>()
+            wsClient.subscribe(params, resultDecoder) { subscriptionResultFuture.complete(it) }
+            val subscriptionResult = subscriptionResultFuture.get()
             subscriptionResult.isSuccess() shouldBe true
 
             val stream = subscriptionResult.unwrap()
@@ -215,7 +222,9 @@ class WsClientTest : FunSpec({
             val params = arrayOf("newHeads")
             val resultDecoder: (JsonParser) -> JsonNode = { Jackson.MAPPER.readTree(it) }
 
-            val subscriptionResult = wsClient.subscribe(params, resultDecoder).get()
+            val subscriptionResultFuture2 = CompletableFuture<Result<ChannelReceiver<JsonNode>, RpcError>>()
+            wsClient.subscribe(params, resultDecoder) { subscriptionResultFuture2.complete(it) }
+            val subscriptionResult = subscriptionResultFuture2.get()
             subscriptionResult.isSuccess() shouldBe true
 
             val stream = subscriptionResult.unwrap()
@@ -275,7 +284,9 @@ class WsClientTest : FunSpec({
             val params = arrayOf("newHeads")
             val resultDecoder: (JsonParser) -> JsonNode = { Jackson.MAPPER.readTree(it) }
 
-            val subscriptionResult = wsClient.subscribe(params, resultDecoder).get()
+            val subscriptionResultFuture3 = CompletableFuture<Result<ChannelReceiver<JsonNode>, RpcError>>()
+            wsClient.subscribe(params, resultDecoder) { subscriptionResultFuture3.complete(it) }
+            val subscriptionResult = subscriptionResultFuture3.get()
             subscriptionResult.isSuccess() shouldBe true
 
             // Send multiple notifications


### PR DESCRIPTION
## Summary
- Replace CompletableFuture return types with callback-based API in JsonRpcClient
- Add `ResultCallback<T>` functional interface for receiving results
- The internal implementations (HttpClient, WsClient) now accept callbacks
- RpcRequest, RpcSubscribe, and BatchRpcRequest use the callback-based API internally while still returning CompletableFuture to callers for backward compatibility
- Updated tests to use the new callback-based API

## Changes
- `JsonRpcClient.request()`, `subscribe()`, and `requestBatch()` now accept a `ResultCallback` parameter instead of returning `CompletableFuture`
- Added `ResultCallback<T>` functional interface with single method `complete(result: T)`
- Updated `HttpClient` and `WsClient` implementations
- Updated `RpcRequest`, `RpcSubscribe`, and `BatchRpcRequest` to use callbacks internally