### PR TITLE
[codex] Use Bignum KT for big numbers

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-project-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-project-conventions.gradle.kts
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 repositories {
     mavenCentral()
+    maven("https://central.sonatype.com/repository/maven-snapshots/")
     google()
 }
 

--- a/ethers-abi/build.gradle.kts
+++ b/ethers-abi/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
                 api(project(":ethers-core"))
                 api(project(":ethers-providers"))
                 api(project(":ethers-signers"))
+                api(libs.bignumkt)
                 implementation(libs.ditchoom.buffer)
                 implementation(libs.kotlinx.atomicfu)
             }

--- a/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/AbiCodec.kt
+++ b/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/AbiCodec.kt
@@ -7,7 +7,7 @@ import io.ethers.abi.AbiCodec.WORD_SIZE_BYTES
 import io.ethers.core.FastHex
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 object AbiCodec {
     private val TWOS_COMPLEMENT_PADDING = (0..<32).map { ByteArray(it) { 0xff.toByte() } }.toTypedArray()

--- a/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/AbiType.kt
+++ b/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/AbiType.kt
@@ -8,7 +8,7 @@ import io.ethers.abi.AbiType.Tuple
 import io.ethers.abi.eip712.EIP712Codec
 import io.ethers.crypto.Hashing
 import java.lang.reflect.Modifier
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.KClass
 
 /**

--- a/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/AbiType.kt
+++ b/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/AbiType.kt
@@ -7,8 +7,8 @@ import io.ethers.abi.AbiType.FixedArray
 import io.ethers.abi.AbiType.Tuple
 import io.ethers.abi.eip712.EIP712Codec
 import io.ethers.crypto.Hashing
-import java.lang.reflect.Modifier
 import io.github.artificialpb.bignum.BigInteger
+import java.lang.reflect.Modifier
 import kotlin.reflect.KClass
 
 /**

--- a/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/EventFilters.kt
+++ b/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/EventFilters.kt
@@ -11,7 +11,7 @@ import io.ethers.providers.middleware.Middleware
 import io.ethers.providers.types.FilterPoller
 import io.ethers.providers.types.RpcRequest
 import io.ethers.providers.types.RpcSubscribe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Filter for non-anonymous events.

--- a/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/call/ConstructorCall.kt
+++ b/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/call/ConstructorCall.kt
@@ -19,7 +19,7 @@ import io.ethers.providers.middleware.Middleware
 import io.ethers.providers.types.PendingInclusion
 import io.ethers.providers.types.PendingTransaction
 import io.ethers.providers.types.RpcRequest
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import java.time.Duration
 
 private val PRESTATE_DIFF_TRACER = PrestateTracer(diffMode = true)

--- a/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/call/ContractCall.kt
+++ b/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/call/ContractCall.kt
@@ -23,7 +23,7 @@ import io.ethers.providers.types.PendingInclusion
 import io.ethers.providers.types.PendingTransaction
 import io.ethers.providers.types.RpcRequest
 import io.ethers.signers.Signer
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Contract call that can be used to both read and write data to the blockchain.

--- a/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/call/FunctionCall.kt
+++ b/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/call/FunctionCall.kt
@@ -13,7 +13,7 @@ import io.ethers.core.types.StateOverride
 import io.ethers.providers.middleware.Middleware
 import io.ethers.providers.types.PendingTransaction
 import io.ethers.providers.types.RpcRequest
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class FunctionCall<T>(
     provider: Middleware,

--- a/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/call/Multicall3.kt
+++ b/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/call/Multicall3.kt
@@ -19,7 +19,7 @@ import io.ethers.core.types.IntoCallRequest
 import io.ethers.providers.middleware.Middleware
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 private typealias EthersResult<T, E> = Result<T, E>
 

--- a/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/call/Multicall3.kt
+++ b/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/call/Multicall3.kt
@@ -17,9 +17,9 @@ import io.ethers.core.types.Bytes
 import io.ethers.core.types.CallRequest
 import io.ethers.core.types.IntoCallRequest
 import io.ethers.providers.middleware.Middleware
+import io.github.artificialpb.bignum.BigInteger
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
-import io.github.artificialpb.bignum.BigInteger
 
 private typealias EthersResult<T, E> = Result<T, E>
 

--- a/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/eip712/EIP712Codec.kt
+++ b/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/eip712/EIP712Codec.kt
@@ -8,7 +8,7 @@ import io.ethers.abi.ContractStruct
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.crypto.Hashing
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 object EIP712Codec {
     /**

--- a/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/eip712/EIP712Domain.kt
+++ b/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/eip712/EIP712Domain.kt
@@ -18,7 +18,7 @@ import io.ethers.core.readBytes
 import io.ethers.core.readOrNull
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 @JsonSerialize(using = EIP712DomainSerializer::class)
 @JsonDeserialize(using = EIP712DomainDeserializer::class)

--- a/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/error/ContractError.kt
+++ b/ethers-abi/src/jvmSharedMain/kotlin/io/ethers/abi/error/ContractError.kt
@@ -6,7 +6,7 @@ import io.ethers.abi.AbiType
 import io.ethers.core.Result
 import io.ethers.core.types.Bytes
 import io.ethers.providers.RpcError
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Error returned from a contract call.

--- a/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/AbiCodecTest.kt
+++ b/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/AbiCodecTest.kt
@@ -2,6 +2,7 @@ package io.ethers.abi
 
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAll
@@ -12,7 +13,6 @@ import io.kotest.property.Exhaustive
 import io.kotest.property.arbitrary.bigInt
 import io.kotest.property.checkAll
 import io.kotest.property.exhaustive.of
-import io.github.artificialpb.bignum.BigInteger
 
 class AbiCodecTest : FunSpec({
     context("encoding") {

--- a/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/AbiCodecTest.kt
+++ b/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/AbiCodecTest.kt
@@ -12,7 +12,7 @@ import io.kotest.property.Exhaustive
 import io.kotest.property.arbitrary.bigInt
 import io.kotest.property.checkAll
 import io.kotest.property.exhaustive.of
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class AbiCodecTest : FunSpec({
     context("encoding") {

--- a/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/AbiEventTest.kt
+++ b/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/AbiEventTest.kt
@@ -10,7 +10,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.Exhaustive
 import io.kotest.property.checkAll
 import io.kotest.property.exhaustive.of
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class AbiEventTest : FunSpec({
     context("topic abi type") {

--- a/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/AbiEventTest.kt
+++ b/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/AbiEventTest.kt
@@ -5,12 +5,12 @@ import io.ethers.core.types.Bytes
 import io.ethers.core.types.Hash
 import io.ethers.core.types.Log
 import io.ethers.providers.middleware.Middleware
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Exhaustive
 import io.kotest.property.checkAll
 import io.kotest.property.exhaustive.of
-import io.github.artificialpb.bignum.BigInteger
 
 class AbiEventTest : FunSpec({
     context("topic abi type") {

--- a/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/eip712/EIP712CodecTest.kt
+++ b/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/eip712/EIP712CodecTest.kt
@@ -7,11 +7,11 @@ import io.ethers.abi.Mail
 import io.ethers.abi.Person
 import io.ethers.core.types.Address
 import io.ethers.core.types.Hash
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import io.github.artificialpb.bignum.BigInteger
 
 class EIP712CodecTest : FunSpec({
     context("encodeType") {

--- a/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/eip712/EIP712CodecTest.kt
+++ b/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/eip712/EIP712CodecTest.kt
@@ -11,7 +11,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class EIP712CodecTest : FunSpec({
     context("encodeType") {

--- a/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/eip712/EIP712DomainTest.kt
+++ b/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/eip712/EIP712DomainTest.kt
@@ -9,7 +9,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class EIP712DomainTest : FunSpec({
     test("tuple contains only non-null fields in correct order") {

--- a/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/eip712/EIP712DomainTest.kt
+++ b/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/eip712/EIP712DomainTest.kt
@@ -5,11 +5,11 @@ import io.ethers.core.Jackson
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Hash
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 
 class EIP712DomainTest : FunSpec({
     test("tuple contains only non-null fields in correct order") {

--- a/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/eip712/EIP712TypedDataTest.kt
+++ b/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/eip712/EIP712TypedDataTest.kt
@@ -6,9 +6,9 @@ import io.ethers.abi.Person
 import io.ethers.core.Jackson
 import io.ethers.core.types.Address
 import io.ethers.core.types.Hash
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 
 class EIP712TypedDataTest : FunSpec({
     context("EIP712TypedData.from") {

--- a/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/eip712/EIP712TypedDataTest.kt
+++ b/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/eip712/EIP712TypedDataTest.kt
@@ -8,7 +8,7 @@ import io.ethers.core.types.Address
 import io.ethers.core.types.Hash
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class EIP712TypedDataTest : FunSpec({
     context("EIP712TypedData.from") {

--- a/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/error/CustomErrorTest.kt
+++ b/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/error/CustomErrorTest.kt
@@ -5,10 +5,10 @@ import io.ethers.abi.AbiType
 import io.ethers.abi.ContractStruct
 import io.ethers.abi.StructFactory
 import io.ethers.core.types.Bytes
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 
 class CustomErrorTest : FunSpec({
     CustomErrorRegistry.prependResolver(MockCustomErrorResolver())

--- a/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/error/CustomErrorTest.kt
+++ b/ethers-abi/src/jvmSharedTest/kotlin/io/ethers/abi/error/CustomErrorTest.kt
@@ -8,7 +8,7 @@ import io.ethers.core.types.Bytes
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class CustomErrorTest : FunSpec({
     CustomErrorRegistry.prependResolver(MockCustomErrorResolver())

--- a/ethers-abigen-plugin/build.gradle.kts
+++ b/ethers-abigen-plugin/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven("https://central.sonatype.com/repository/maven-snapshots/")
 }
 
 kotlin {

--- a/ethers-abigen/build.gradle.kts
+++ b/ethers-abigen/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
                 api(project(":ethers-core"))
                 api(project(":ethers-providers"))
                 api(project(":ethers-abi"))
+                api(libs.bignumkt)
 
                 implementation(libs.kotlin.reflect)
                 implementation(libs.kotlinx.atomicfu)

--- a/ethers-abigen/src/jvmSharedMain/kotlin/io/ethers/abigen/AbiContractBuilder.kt
+++ b/ethers-abigen/src/jvmSharedMain/kotlin/io/ethers/abigen/AbiContractBuilder.kt
@@ -38,8 +38,8 @@ import io.ethers.core.types.Bytes
 import io.ethers.core.types.Hash
 import io.ethers.core.types.Log
 import io.ethers.providers.middleware.Middleware
+import io.github.artificialpb.bignum.BigInteger
 import java.io.File
-import java.math.BigInteger
 import javax.lang.model.SourceVersion
 import kotlin.reflect.KClass
 import kotlin.reflect.full.functions

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/BeefyV1Test.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/BeefyV1Test.kt
@@ -17,10 +17,10 @@ import io.ethers.abigen.typedNestedClass
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.providers.middleware.Middleware
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.full.companionObject
 import kotlin.reflect.full.isSubclassOf
 

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/BeefyV1Test.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/BeefyV1Test.kt
@@ -20,7 +20,7 @@ import io.ethers.providers.middleware.Middleware
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.full.companionObject
 import kotlin.reflect.full.isSubclassOf
 

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/ConstructorsTest.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/ConstructorsTest.kt
@@ -10,9 +10,9 @@ import io.ethers.abigen.getDeclaredFunctions
 import io.ethers.abigen.nestedClass
 import io.ethers.abigen.parametrizedBy
 import io.ethers.providers.middleware.Middleware
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.full.companionObject
 import kotlin.reflect.full.isSubclassOf
 

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/ConstructorsTest.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/ConstructorsTest.kt
@@ -12,7 +12,7 @@ import io.ethers.abigen.parametrizedBy
 import io.ethers.providers.middleware.Middleware
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.full.companionObject
 import kotlin.reflect.full.isSubclassOf
 

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/ErrorsTest.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/ErrorsTest.kt
@@ -12,10 +12,10 @@ import io.ethers.abigen.nestedClass
 import io.ethers.abigen.parametrizedBy
 import io.ethers.abigen.typedNestedClass
 import io.ethers.core.types.Bytes
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.primaryConstructor
 

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/ErrorsTest.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/ErrorsTest.kt
@@ -15,7 +15,7 @@ import io.ethers.core.types.Bytes
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.primaryConstructor
 

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/EventsTest.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/EventsTest.kt
@@ -17,7 +17,7 @@ import io.ethers.core.types.Log
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.primaryConstructor
 

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/EventsTest.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/EventsTest.kt
@@ -14,10 +14,10 @@ import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Hash
 import io.ethers.core.types.Log
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.primaryConstructor
 

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/FunctionsTest.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/FunctionsTest.kt
@@ -13,10 +13,10 @@ import io.ethers.abigen.nestedClass
 import io.ethers.abigen.parametrizedBy
 import io.ethers.core.types.Address
 import io.ethers.providers.middleware.Middleware
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.full.companionObject
 
 class FunctionsTest : FunSpec({

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/FunctionsTest.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/FunctionsTest.kt
@@ -16,7 +16,7 @@ import io.ethers.providers.middleware.Middleware
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.full.companionObject
 
 class FunctionsTest : FunSpec({

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/ReceiveFallbackTest.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/ReceiveFallbackTest.kt
@@ -10,7 +10,7 @@ import io.ethers.core.types.Bytes
 import io.ethers.providers.middleware.Middleware
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.full.companionObject
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.declaredFunctions

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/ReceiveFallbackTest.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/ReceiveFallbackTest.kt
@@ -8,9 +8,9 @@ import io.ethers.abigen.parametrizedBy
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.providers.middleware.Middleware
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.full.companionObject
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.declaredFunctions

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/StructsTest.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/StructsTest.kt
@@ -11,10 +11,10 @@ import io.ethers.abigen.nestedClass
 import io.ethers.abigen.parametrizedBy
 import io.ethers.abigen.typedNestedClass
 import io.ethers.core.types.Bytes
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.full.companionObjectInstance
 import kotlin.reflect.full.primaryConstructor
 

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/StructsTest.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/StructsTest.kt
@@ -14,7 +14,7 @@ import io.ethers.core.types.Bytes
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.full.companionObjectInstance
 import kotlin.reflect.full.primaryConstructor
 

--- a/ethers-core/build.gradle.kts
+++ b/ethers-core/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
                 api(project(":ethers-rlp"))
                 api(project(":ethers-crypto"))
 
+                api(libs.bignumkt)
                 api(libs.bundles.jackson)
             }
         }

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/FastHex.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/FastHex.kt
@@ -17,7 +17,7 @@
 package io.ethers.core
 
 import io.ethers.core.FastHex.decode
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Hexadecimal codec with safe-by-default and unsafe encoding/decoding support.

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/Jackson.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/Jackson.kt
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import java.io.InputStream
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Static [JsonMapper] with default settings. Instance should be reused. Customized reading/writing can be achieved

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/Jackson.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/Jackson.kt
@@ -14,8 +14,8 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
-import java.io.InputStream
 import io.github.artificialpb.bignum.BigInteger
+import java.io.InputStream
 
 /**
  * Static [JsonMapper] with default settings. Instance should be reused. Customized reading/writing can be achieved

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/JsonParserExtensions.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/JsonParserExtensions.kt
@@ -7,7 +7,7 @@ import io.ethers.core.types.Address
 import io.ethers.core.types.Bloom
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Hash
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Check if end of JSON object is reached.

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/AccountOverride.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/AccountOverride.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import io.ethers.core.FastHex
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * An account override, used to override the nonce, balance, code, and storage of an account.

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/Authorization.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/Authorization.kt
@@ -21,7 +21,7 @@ import io.ethers.rlp.RlpDecodable
 import io.ethers.rlp.RlpDecoder
 import io.ethers.rlp.RlpEncodable
 import io.ethers.rlp.RlpEncoder
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * EIP-7702 Authorization structure for SetCode transactions.

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/Block.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/Block.kt
@@ -18,7 +18,7 @@ import io.ethers.core.readHexLong
 import io.ethers.core.readListOf
 import io.ethers.core.readListOfHashes
 import io.ethers.core.readOrNull
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 @JsonDeserialize(using = BlockWithHashesDeserializer::class)
 data class BlockWithHashes(

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/BlockOverride.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/BlockOverride.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import io.ethers.core.FastHex
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Block override, which can be used to override certain fields of a block, such as the block number, timestamp,

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/CallRequest.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/CallRequest.kt
@@ -11,7 +11,7 @@ import io.ethers.core.types.transaction.TxAccessList
 import io.ethers.core.types.transaction.TxBlob
 import io.ethers.core.types.transaction.TxDynamicFee
 import io.ethers.core.types.transaction.TxLegacy
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 @JsonSerialize(using = CallRequestSerializer::class)
 class CallRequest() : IntoCallRequest {

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/FeeHistory.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/FeeHistory.kt
@@ -9,7 +9,7 @@ import io.ethers.core.readAnyLong
 import io.ethers.core.readHexBigInteger
 import io.ethers.core.readListOf
 import io.ethers.core.readOrNull
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * This class represents a FeeHistory.

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/Hash.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/Hash.kt
@@ -18,7 +18,7 @@ import io.ethers.rlp.RlpDecodable
 import io.ethers.rlp.RlpDecoder
 import io.ethers.rlp.RlpEncodable
 import io.ethers.rlp.RlpEncoder
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * 32-byte hash.

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/RPCTransaction.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/RPCTransaction.kt
@@ -20,7 +20,7 @@ import io.ethers.core.readOrNull
 import io.ethers.core.types.transaction.ChainId
 import io.ethers.core.types.transaction.TransactionRecovered
 import io.ethers.core.types.transaction.TxType
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 @JsonDeserialize(using = RPCTransactionDeserializer::class)
 data class RPCTransaction(

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/Signature.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/Signature.kt
@@ -10,7 +10,7 @@ import io.ethers.rlp.RlpDecodable
 import io.ethers.rlp.RlpDecoder
 import io.ethers.rlp.RlpEncodable
 import io.ethers.rlp.RlpEncoder
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class Signature(
     val r: BigInteger,

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/TransactionReceipt.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/TransactionReceipt.kt
@@ -18,7 +18,7 @@ import io.ethers.core.readHexLong
 import io.ethers.core.readListOf
 import io.ethers.core.readOrNull
 import io.ethers.core.types.transaction.TxType
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Result of transaction execution.

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/tracers/CallTracer.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/tracers/CallTracer.kt
@@ -19,7 +19,7 @@ import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Hash
 import io.ethers.core.types.Log
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.KClass
 
 /**

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/tracers/PrestateTracer.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/tracers/PrestateTracer.kt
@@ -14,7 +14,7 @@ import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Hash
 import io.ethers.core.types.StateOverride
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import kotlin.reflect.KClass
 
 /**

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/transaction/Transaction.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/transaction/Transaction.kt
@@ -9,7 +9,7 @@ import io.ethers.core.types.Hash
 import io.ethers.core.types.IntoCallRequest
 import io.ethers.core.types.Signature
 import io.ethers.core.utils.GasUtils
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * A [Transaction] with recovered sender address ([from]) and [hash].

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/transaction/TxAccessList.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/transaction/TxAccessList.kt
@@ -9,7 +9,7 @@ import io.ethers.core.types.Signature
 import io.ethers.rlp.RlpDecodable
 import io.ethers.rlp.RlpDecoder
 import io.ethers.rlp.RlpEncoder
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * EIP-2930 transaction with optional access list.

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/transaction/TxBlob.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/transaction/TxBlob.kt
@@ -11,7 +11,7 @@ import io.ethers.rlp.RlpDecodable
 import io.ethers.rlp.RlpDecoder
 import io.ethers.rlp.RlpEncodable
 import io.ethers.rlp.RlpEncoder
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * An [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) blob-carrying transaction with additional

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/transaction/TxDynamicFee.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/transaction/TxDynamicFee.kt
@@ -9,7 +9,7 @@ import io.ethers.core.types.Signature
 import io.ethers.rlp.RlpDecodable
 import io.ethers.rlp.RlpDecoder
 import io.ethers.rlp.RlpEncoder
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * EIP-1559 transaction with optional access list and [gasFeeCap]/[gasTipCap] instead of [gasPrice].

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/transaction/TxLegacy.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/transaction/TxLegacy.kt
@@ -9,7 +9,7 @@ import io.ethers.core.types.Signature
 import io.ethers.rlp.RlpDecodable
 import io.ethers.rlp.RlpDecoder
 import io.ethers.rlp.RlpEncoder
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 data class TxLegacy(
     override val to: Address?,

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/transaction/TxSetCode.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/transaction/TxSetCode.kt
@@ -9,7 +9,7 @@ import io.ethers.core.types.Signature
 import io.ethers.rlp.RlpDecodable
 import io.ethers.rlp.RlpDecoder
 import io.ethers.rlp.RlpEncoder
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * EIP-7702 SetCode transaction with authorization list for delegating contract code execution.

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/utils/EthUnit.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/utils/EthUnit.kt
@@ -3,8 +3,8 @@ package io.ethers.core.utils
 import io.ethers.core.utils.EthUnit.Companion.ETHER
 import io.ethers.core.utils.EthUnit.Companion.GWEI
 import io.ethers.core.utils.EthUnit.Companion.WEI
-import java.math.BigDecimal
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigDecimal
+import io.github.artificialpb.bignum.BigInteger
 import java.math.RoundingMode
 
 /**

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/utils/GasUtils.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/utils/GasUtils.kt
@@ -1,7 +1,7 @@
 package io.ethers.core.utils
 
 import io.ethers.core.utils.GasUtils.getEffectiveGasTip
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 object GasUtils {
     /**

--- a/ethers-core/src/jvmSharedTest/kotlin/fixtures/AuthorizationFactory.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/fixtures/AuthorizationFactory.kt
@@ -2,7 +2,7 @@ package fixtures
 
 import io.ethers.core.types.Address
 import io.ethers.core.types.Authorization
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 object AuthorizationFactory {
     fun create(

--- a/ethers-core/src/jvmSharedTest/kotlin/fixtures/TxAccessListFactory.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/fixtures/TxAccessListFactory.kt
@@ -4,7 +4,7 @@ import io.ethers.core.types.AccessList
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.transaction.TxAccessList
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 object TxAccessListFactory {
     fun create(

--- a/ethers-core/src/jvmSharedTest/kotlin/fixtures/TxDynamicFeeFactory.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/fixtures/TxDynamicFeeFactory.kt
@@ -4,7 +4,7 @@ import io.ethers.core.types.AccessList
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.transaction.TxDynamicFee
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 object TxDynamicFeeFactory {
     fun create(

--- a/ethers-core/src/jvmSharedTest/kotlin/fixtures/TxSetCodeFactory.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/fixtures/TxSetCodeFactory.kt
@@ -5,7 +5,7 @@ import io.ethers.core.types.Address
 import io.ethers.core.types.Authorization
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.transaction.TxSetCode
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 object TxSetCodeFactory {
     fun create(

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/FastHexTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/FastHexTest.kt
@@ -1,5 +1,6 @@
 package io.ethers.core
 
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
@@ -12,7 +13,6 @@ import io.kotest.property.arbitrary.byteArray
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.long
 import io.kotest.property.checkAll
-import io.github.artificialpb.bignum.BigInteger
 
 class FastHexTest : FunSpec({
     test("encode/decode as string without prefix") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/FastHexTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/FastHexTest.kt
@@ -12,7 +12,7 @@ import io.kotest.property.arbitrary.byteArray
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.long
 import io.kotest.property.checkAll
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class FastHexTest : FunSpec({
     test("encode/decode as string without prefix") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/JsonParserExtensionsTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/JsonParserExtensionsTest.kt
@@ -6,10 +6,10 @@ import com.fasterxml.jackson.core.JsonToken
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Hash
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 
 class JsonParserExtensionsTest : FunSpec({
     val factory = JsonFactory()

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/JsonParserExtensionsTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/JsonParserExtensionsTest.kt
@@ -9,7 +9,7 @@ import io.ethers.core.types.Hash
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class JsonParserExtensionsTest : FunSpec({
     val factory = JsonFactory()

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/AccountOverrideTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/AccountOverrideTest.kt
@@ -5,7 +5,7 @@ import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class AccountOverrideTest : FunSpec({
     test("serialization - state") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/AccountOverrideTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/AccountOverrideTest.kt
@@ -1,11 +1,11 @@
 package io.ethers.core.types
 
 import io.ethers.core.Jackson
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 
 class AccountOverrideTest : FunSpec({
     test("serialization - state") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/AuthorizationTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/AuthorizationTest.kt
@@ -8,7 +8,7 @@ import io.ethers.rlp.RlpEncoder
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class AuthorizationTest : FunSpec({
 

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/AuthorizationTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/AuthorizationTest.kt
@@ -5,10 +5,10 @@ import io.ethers.core.Jackson
 import io.ethers.core.types.Authorization.Companion.MAGIC
 import io.ethers.rlp.RlpDecoder
 import io.ethers.rlp.RlpEncoder
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 
 class AuthorizationTest : FunSpec({
 

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/BlockOverrideTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/BlockOverrideTest.kt
@@ -1,13 +1,13 @@
 package io.ethers.core.types
 
 import io.ethers.core.Jackson
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.github.artificialpb.bignum.BigInteger
 
 class BlockOverrideTest : FunSpec({
     test("BlockOverride serialization - all fields") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/BlockOverrideTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/BlockOverrideTest.kt
@@ -7,7 +7,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class BlockOverrideTest : FunSpec({
     test("BlockOverride serialization - all fields") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/BlockTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/BlockTest.kt
@@ -6,7 +6,7 @@ import io.ethers.core.types.transaction.TxType
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import org.intellij.lang.annotations.Language
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class BlockTest : FunSpec({
     test("BlockWithHashes deserialization") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/BlockTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/BlockTest.kt
@@ -3,10 +3,10 @@ package io.ethers.core.types
 import io.ethers.core.Jackson
 import io.ethers.core.json.JsonElement
 import io.ethers.core.types.transaction.TxType
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import org.intellij.lang.annotations.Language
-import io.github.artificialpb.bignum.BigInteger
 
 class BlockTest : FunSpec({
     test("BlockWithHashes deserialization") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/BytesTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/BytesTest.kt
@@ -1,11 +1,11 @@
 package io.ethers.core.types
 
 import io.ethers.core.Jackson
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 
 class BytesTest : FunSpec({
     context("equals") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/BytesTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/BytesTest.kt
@@ -5,7 +5,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class BytesTest : FunSpec({
     context("equals") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/CallRequestTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/CallRequestTest.kt
@@ -5,6 +5,7 @@ import io.ethers.core.types.transaction.TxAccessList
 import io.ethers.core.types.transaction.TxBlob
 import io.ethers.core.types.transaction.TxDynamicFee
 import io.ethers.core.types.transaction.TxLegacy
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.FunSpec
@@ -12,7 +13,6 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import io.github.artificialpb.bignum.BigInteger
 
 class CallRequestTest : FunSpec({
     test("CallRequest serialization") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/CallRequestTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/CallRequestTest.kt
@@ -12,7 +12,7 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class CallRequestTest : FunSpec({
     test("CallRequest serialization") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/FeeHistoryTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/FeeHistoryTest.kt
@@ -1,10 +1,10 @@
 package io.ethers.core.types
 
 import io.ethers.core.Jackson
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import org.intellij.lang.annotations.Language
-import io.github.artificialpb.bignum.BigInteger
 
 class FeeHistoryTest : FunSpec({
     test("FeeHistory deserialization - new format") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/FeeHistoryTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/FeeHistoryTest.kt
@@ -4,7 +4,7 @@ import io.ethers.core.Jackson
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import org.intellij.lang.annotations.Language
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class FeeHistoryTest : FunSpec({
     test("FeeHistory deserialization - new format") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/HashTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/HashTest.kt
@@ -10,7 +10,7 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bigInt
 import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class HashTest : FunSpec({
 

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/HashTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/HashTest.kt
@@ -2,6 +2,7 @@ package io.ethers.core.types
 
 import io.ethers.core.FastHex
 import io.ethers.core.Jackson
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
@@ -10,7 +11,6 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bigInt
 import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
-import io.github.artificialpb.bignum.BigInteger
 
 class HashTest : FunSpec({
 

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/RPCTransactionTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/RPCTransactionTest.kt
@@ -4,10 +4,10 @@ import io.ethers.core.Jackson
 import io.ethers.core.json.JsonElement
 import io.ethers.core.types.transaction.TxBlob
 import io.ethers.core.types.transaction.TxType
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import org.intellij.lang.annotations.Language
-import io.github.artificialpb.bignum.BigInteger
 
 class RPCTransactionTest : FunSpec({
     test("deserialization") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/RPCTransactionTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/RPCTransactionTest.kt
@@ -7,7 +7,7 @@ import io.ethers.core.types.transaction.TxType
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import org.intellij.lang.annotations.Language
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class RPCTransactionTest : FunSpec({
     test("deserialization") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/SignatureTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/SignatureTest.kt
@@ -2,12 +2,12 @@ package io.ethers.core.types
 
 import io.ethers.core.isFailure
 import io.ethers.core.isSuccess
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import io.github.artificialpb.bignum.BigInteger
 
 class SignatureTest : FunSpec({
     context("invalid recoveryId") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/SignatureTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/SignatureTest.kt
@@ -7,7 +7,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class SignatureTest : FunSpec({
     context("invalid recoveryId") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/StateOverrideTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/StateOverrideTest.kt
@@ -4,7 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class StateOverrideTest : FunSpec({
     val addr1 = Address("0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5")

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/StateOverrideTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/StateOverrideTest.kt
@@ -1,10 +1,10 @@
 package io.ethers.core.types
 
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.github.artificialpb.bignum.BigInteger
 
 class StateOverrideTest : FunSpec({
     val addr1 = Address("0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5")

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/TransactionReceiptTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/TransactionReceiptTest.kt
@@ -6,7 +6,7 @@ import io.ethers.core.types.transaction.TxType
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import org.intellij.lang.annotations.Language
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class TransactionReceiptTest : FunSpec({
     test("deserialization") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/TransactionReceiptTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/TransactionReceiptTest.kt
@@ -3,10 +3,10 @@ package io.ethers.core.types
 import io.ethers.core.Jackson
 import io.ethers.core.json.JsonElement
 import io.ethers.core.types.transaction.TxType
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import org.intellij.lang.annotations.Language
-import io.github.artificialpb.bignum.BigInteger
 
 class TransactionReceiptTest : FunSpec({
     test("deserialization") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/TxpoolTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/TxpoolTest.kt
@@ -2,10 +2,10 @@ package io.ethers.core.types
 
 import io.ethers.core.Jackson
 import io.ethers.core.types.transaction.TxType
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import org.intellij.lang.annotations.Language
-import io.github.artificialpb.bignum.BigInteger
 
 class TxpoolTest : FunSpec({
     test("TxpoolContent deserialization") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/TxpoolTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/TxpoolTest.kt
@@ -5,7 +5,7 @@ import io.ethers.core.types.transaction.TxType
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import org.intellij.lang.annotations.Language
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class TxpoolTest : FunSpec({
     test("TxpoolContent deserialization") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/tracers/CallTracerTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/tracers/CallTracerTest.kt
@@ -5,6 +5,7 @@ import io.ethers.core.json.JsonElement
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Hash
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
@@ -12,7 +13,6 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import org.intellij.lang.annotations.Language
-import io.github.artificialpb.bignum.BigInteger
 
 class CallTracerTest : FunSpec({
     val callTracer = CallTracer(onlyTopCall = true, withLog = true)

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/tracers/CallTracerTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/tracers/CallTracerTest.kt
@@ -12,7 +12,7 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import org.intellij.lang.annotations.Language
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class CallTracerTest : FunSpec({
     val callTracer = CallTracer(onlyTopCall = true, withLog = true)

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/tracers/MuxTracerTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/tracers/MuxTracerTest.kt
@@ -13,7 +13,7 @@ import io.kotest.inspectors.forAll
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import org.intellij.lang.annotations.Language
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class MuxTracerTest : FunSpec({
     val callTracer = CallTracer(onlyTopCall = true, withLog = true)

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/tracers/MuxTracerTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/tracers/MuxTracerTest.kt
@@ -5,6 +5,7 @@ import io.ethers.core.Jackson.createAndInitParser
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Hash
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
@@ -13,7 +14,6 @@ import io.kotest.inspectors.forAll
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import org.intellij.lang.annotations.Language
-import io.github.artificialpb.bignum.BigInteger
 
 class MuxTracerTest : FunSpec({
     val callTracer = CallTracer(onlyTopCall = true, withLog = true)

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/tracers/PrestateTracerTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/tracers/PrestateTracerTest.kt
@@ -10,7 +10,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import org.intellij.lang.annotations.Language
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class PrestateTracerTest : FunSpec({
     test("encode tracer") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/tracers/PrestateTracerTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/tracers/PrestateTracerTest.kt
@@ -5,12 +5,12 @@ import io.ethers.core.types.AccountOverride
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Hash
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import org.intellij.lang.annotations.Language
-import io.github.artificialpb.bignum.BigInteger
 
 class PrestateTracerTest : FunSpec({
     test("encode tracer") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/transactions/TransactionSignedTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/transactions/TransactionSignedTest.kt
@@ -17,6 +17,7 @@ import io.ethers.core.types.transaction.TxLegacy
 import io.ethers.core.types.transaction.TxType
 import io.ethers.rlp.RlpDecoder
 import io.ethers.rlp.RlpEncoder
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.WithDataTestName
 import io.kotest.datatest.withData
@@ -33,7 +34,6 @@ import io.kotest.property.checkAll
 import io.kotest.property.exhaustive.map
 import io.kotest.property.exhaustive.of
 import java.io.File
-import io.github.artificialpb.bignum.BigInteger
 import kotlin.random.Random
 
 class TransactionSignedTest : FunSpec({

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/transactions/TransactionSignedTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/transactions/TransactionSignedTest.kt
@@ -33,7 +33,7 @@ import io.kotest.property.checkAll
 import io.kotest.property.exhaustive.map
 import io.kotest.property.exhaustive.of
 import java.io.File
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import kotlin.random.Random
 
 class TransactionSignedTest : FunSpec({

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/transactions/TransactionUnsignedTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/transactions/TransactionUnsignedTest.kt
@@ -19,7 +19,7 @@ import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class TransactionUnsignedTest : FunSpec({
     val accessList = listOf(

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/transactions/TransactionUnsignedTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/transactions/TransactionUnsignedTest.kt
@@ -14,12 +14,12 @@ import io.ethers.core.types.transaction.TxLegacy
 import io.ethers.core.types.transaction.TxSetCode
 import io.ethers.rlp.RlpDecoder
 import io.ethers.rlp.RlpEncoder
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import io.github.artificialpb.bignum.BigInteger
 
 class TransactionUnsignedTest : FunSpec({
     val accessList = listOf(

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/transactions/TxSetCodeTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/transactions/TxSetCodeTest.kt
@@ -4,10 +4,10 @@ import fixtures.TxSetCodeFactory
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.transaction.TxType
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 
 class TxSetCodeTest : FunSpec({
     context("initialization") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/transactions/TxSetCodeTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/transactions/TxSetCodeTest.kt
@@ -7,7 +7,7 @@ import io.ethers.core.types.transaction.TxType
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class TxSetCodeTest : FunSpec({
     context("initialization") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/utils/EthUnitTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/utils/EthUnitTest.kt
@@ -6,8 +6,8 @@ import io.kotest.matchers.comparables.shouldBeEqualComparingTo
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bigInt
 import io.kotest.property.checkAll
-import java.math.BigDecimal
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigDecimal
+import io.github.artificialpb.bignum.BigInteger
 
 class EthUnitTest : FunSpec({
     data class ConversionTestData(

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/utils/EthUnitTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/utils/EthUnitTest.kt
@@ -1,13 +1,13 @@
 package io.ethers.core.utils
 
+import io.github.artificialpb.bignum.BigDecimal
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.comparables.shouldBeEqualComparingTo
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bigInt
 import io.kotest.property.checkAll
-import io.github.artificialpb.bignum.BigDecimal
-import io.github.artificialpb.bignum.BigInteger
 
 class EthUnitTest : FunSpec({
     data class ConversionTestData(

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/utils/GasUtilsTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/utils/GasUtilsTest.kt
@@ -2,7 +2,7 @@ package io.ethers.core.utils
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class GasUtilsTest : FunSpec({
     context("getEffectiveGasTip") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/utils/GasUtilsTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/utils/GasUtilsTest.kt
@@ -1,8 +1,8 @@
 package io.ethers.core.utils
 
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 
 class GasUtilsTest : FunSpec({
     context("getEffectiveGasTip") {

--- a/ethers-crypto/build.gradle.kts
+++ b/ethers-crypto/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
     sourceSets {
         val jvmSharedMain by getting {
             dependencies {
+                api(libs.bignumkt)
                 implementation(libs.kotlincrypto.hash.sha3)
                 implementation(libs.whyoleg.cryptography.core)
                 implementation(libs.whyoleg.cryptography.random)

--- a/ethers-crypto/src/jvmSharedMain/kotlin/io/ethers/crypto/Secp256k1.kt
+++ b/ethers-crypto/src/jvmSharedMain/kotlin/io/ethers/crypto/Secp256k1.kt
@@ -1,6 +1,6 @@
 package io.ethers.crypto
 
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import fr.acinq.secp256k1.Secp256k1 as AcinqSecp256k1
 
 /**

--- a/ethers-crypto/src/jvmSharedTest/kotlin/io/ethers/crypto/Secp256k1Test.kt
+++ b/ethers-crypto/src/jvmSharedTest/kotlin/io/ethers/crypto/Secp256k1Test.kt
@@ -1,5 +1,6 @@
 package io.ethers.crypto
 
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAll
@@ -8,7 +9,6 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bigInt
 import io.kotest.property.checkAll
-import io.github.artificialpb.bignum.BigInteger
 
 class Secp256k1Test : FunSpec({
     context("publicKeyToAddress") {

--- a/ethers-crypto/src/jvmSharedTest/kotlin/io/ethers/crypto/Secp256k1Test.kt
+++ b/ethers-crypto/src/jvmSharedTest/kotlin/io/ethers/crypto/Secp256k1Test.kt
@@ -8,7 +8,7 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bigInt
 import io.kotest.property.checkAll
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class Secp256k1Test : FunSpec({
     context("publicKeyToAddress") {

--- a/ethers-ens/build.gradle.kts
+++ b/ethers-ens/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
                 api(project(":ethers-core"))
                 api(project(":ethers-abi"))
                 api(project(":ethers-providers"))
+                api(libs.bignumkt)
 
                 implementation(project(":logger"))
             }

--- a/ethers-ens/src/jvmSharedMain/kotlin/io/ethers/ens/Avatar.kt
+++ b/ethers-ens/src/jvmSharedMain/kotlin/io/ethers/ens/Avatar.kt
@@ -7,7 +7,7 @@ import io.ethers.core.failure
 import io.ethers.core.success
 import io.ethers.core.types.Address
 import io.ethers.core.unwrapOrReturn
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 internal data class MetadataDTO(

--- a/ethers-ens/src/jvmSharedMain/kotlin/io/ethers/ens/ERC1155.kt
+++ b/ethers-ens/src/jvmSharedMain/kotlin/io/ethers/ens/ERC1155.kt
@@ -15,7 +15,7 @@ import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Log
 import io.ethers.providers.middleware.Middleware
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 public class ERC1155(
     provider: Middleware,
@@ -33,7 +33,7 @@ public class ERC1155(
      */
     public fun balanceOf(_owner: Address, _id: BigInteger): ReadFunctionCall<BigInteger> = ReadFunctionCall(this.provider, this.address, FUNCTION_BALANCE_OF.encodeCall(listOf(_owner, _id))) {
         val data = FUNCTION_BALANCE_OF.decodeResponse(it)
-        data[0] as java.math.BigInteger
+        data[0] as io.github.artificialpb.bignum.BigInteger
     }
 
     /**
@@ -52,7 +52,7 @@ public class ERC1155(
         FUNCTION_BALANCE_OF_BATCH.encodeCall(listOf<Any>(_owners, _ids)),
     ) {
         val data = FUNCTION_BALANCE_OF_BATCH.decodeResponse(it)
-        data[0] as List<java.math.BigInteger>
+        data[0] as List<io.github.artificialpb.bignum.BigInteger>
     }
 
     /**
@@ -358,8 +358,8 @@ public class ERC1155(
                 data[0] as io.ethers.core.types.Address,
                 data[1] as io.ethers.core.types.Address,
                 data[2] as io.ethers.core.types.Address,
-                data[3] as List<java.math.BigInteger>,
-                data[4] as List<java.math.BigInteger>,
+                data[3] as List<io.github.artificialpb.bignum.BigInteger>,
+                data[4] as List<io.github.artificialpb.bignum.BigInteger>,
                 log,
             )
         }
@@ -434,8 +434,8 @@ public class ERC1155(
                 data[0] as io.ethers.core.types.Address,
                 data[1] as io.ethers.core.types.Address,
                 data[2] as io.ethers.core.types.Address,
-                data[3] as java.math.BigInteger,
-                data[4] as java.math.BigInteger,
+                data[3] as io.github.artificialpb.bignum.BigInteger,
+                data[4] as io.github.artificialpb.bignum.BigInteger,
                 log,
             )
         }
@@ -491,7 +491,7 @@ public class ERC1155(
             override fun decode(log: Log): URI? = super.decode(log)
 
             @JvmStatic
-            override fun decode(log: Log, `data`: List<Any>): URI = URI(data[0] as kotlin.String, data[1] as java.math.BigInteger, log)
+            override fun decode(log: Log, `data`: List<Any>): URI = URI(data[0] as kotlin.String, data[1] as io.github.artificialpb.bignum.BigInteger, log)
         }
     }
 

--- a/ethers-ens/src/jvmSharedMain/kotlin/io/ethers/ens/ERC721.kt
+++ b/ethers-ens/src/jvmSharedMain/kotlin/io/ethers/ens/ERC721.kt
@@ -16,7 +16,7 @@ import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Log
 import io.ethers.providers.middleware.Middleware
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 public class ERC721(
     provider: Middleware,
@@ -47,7 +47,7 @@ public class ERC721(
      */
     public fun balanceOf(_owner: Address): ReadFunctionCall<BigInteger> = ReadFunctionCall(this.provider, this.address, FUNCTION_BALANCE_OF.encodeCall(listOf<Any>(_owner))) {
         val data = FUNCTION_BALANCE_OF.decodeResponse(it)
-        data[0] as java.math.BigInteger
+        data[0] as io.github.artificialpb.bignum.BigInteger
     }
 
     /**
@@ -220,7 +220,7 @@ public class ERC721(
      */
     public fun tokenByIndex(_index: BigInteger): ReadFunctionCall<BigInteger> = ReadFunctionCall(this.provider, this.address, FUNCTION_TOKEN_BY_INDEX.encodeCall(listOf<Any>(_index))) {
         val data = FUNCTION_TOKEN_BY_INDEX.decodeResponse(it)
-        data[0] as java.math.BigInteger
+        data[0] as io.github.artificialpb.bignum.BigInteger
     }
 
     /**
@@ -235,7 +235,7 @@ public class ERC721(
      */
     public fun tokenOfOwnerByIndex(_owner: Address, _index: BigInteger): ReadFunctionCall<BigInteger> = ReadFunctionCall(this.provider, this.address, FUNCTION_TOKEN_OF_OWNER_BY_INDEX.encodeCall(listOf(_owner, _index))) {
         val data = FUNCTION_TOKEN_OF_OWNER_BY_INDEX.decodeResponse(it)
-        data[0] as java.math.BigInteger
+        data[0] as io.github.artificialpb.bignum.BigInteger
     }
 
     /**
@@ -265,7 +265,7 @@ public class ERC721(
      */
     public fun totalSupply(): ReadFunctionCall<BigInteger> = ReadFunctionCall(this.provider, this.address, FUNCTION_TOTAL_SUPPLY.encodeCall(emptyList())) {
         val data = FUNCTION_TOTAL_SUPPLY.decodeResponse(it)
-        data[0] as java.math.BigInteger
+        data[0] as io.github.artificialpb.bignum.BigInteger
     }
 
     /**
@@ -336,7 +336,7 @@ public class ERC721(
             override fun decode(log: Log): Approval? = super.decode(log)
 
             @JvmStatic
-            override fun decode(log: Log, `data`: List<Any>): Approval = Approval(data[0] as io.ethers.core.types.Address, data[1] as io.ethers.core.types.Address, data[2] as java.math.BigInteger, log)
+            override fun decode(log: Log, `data`: List<Any>): Approval = Approval(data[0] as io.ethers.core.types.Address, data[1] as io.ethers.core.types.Address, data[2] as io.github.artificialpb.bignum.BigInteger, log)
         }
     }
 
@@ -442,7 +442,7 @@ public class ERC721(
             override fun decode(log: Log): Transfer? = super.decode(log)
 
             @JvmStatic
-            override fun decode(log: Log, `data`: List<Any>): Transfer = Transfer(data[0] as io.ethers.core.types.Address, data[1] as io.ethers.core.types.Address, data[2] as java.math.BigInteger, log)
+            override fun decode(log: Log, `data`: List<Any>): Transfer = Transfer(data[0] as io.ethers.core.types.Address, data[1] as io.ethers.core.types.Address, data[2] as io.github.artificialpb.bignum.BigInteger, log)
         }
     }
 

--- a/ethers-ens/src/jvmSharedMain/kotlin/io/ethers/ens/EnsMiddleware.kt
+++ b/ethers-ens/src/jvmSharedMain/kotlin/io/ethers/ens/EnsMiddleware.kt
@@ -23,12 +23,12 @@ import io.ethers.logger.err
 import io.ethers.logger.getLogger
 import io.ethers.logger.wrn
 import io.ethers.providers.middleware.Middleware
+import io.github.artificialpb.bignum.BigInteger
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import io.github.artificialpb.bignum.BigInteger
 import java.util.concurrent.CompletableFuture
 
 class EnsMiddleware @JvmOverloads constructor(

--- a/ethers-ens/src/jvmSharedMain/kotlin/io/ethers/ens/EnsMiddleware.kt
+++ b/ethers-ens/src/jvmSharedMain/kotlin/io/ethers/ens/EnsMiddleware.kt
@@ -28,7 +28,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import java.util.concurrent.CompletableFuture
 
 class EnsMiddleware @JvmOverloads constructor(

--- a/ethers-ens/src/jvmSharedMain/kotlin/io/ethers/ens/EnsRegistry.kt
+++ b/ethers-ens/src/jvmSharedMain/kotlin/io/ethers/ens/EnsRegistry.kt
@@ -15,7 +15,7 @@ import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Log
 import io.ethers.providers.middleware.Middleware
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 public class EnsRegistry(
     provider: Middleware,
@@ -201,7 +201,7 @@ public class EnsRegistry(
      */
     public fun ttl(node: Bytes): ReadFunctionCall<BigInteger> = ReadFunctionCall(this.provider, this.address, FUNCTION_TTL.encodeCall(listOf<Any>(node))) {
         val data = FUNCTION_TTL.decodeResponse(it)
-        data[0] as java.math.BigInteger
+        data[0] as io.github.artificialpb.bignum.BigInteger
     }
 
     public sealed class Event : ContractEvent
@@ -408,7 +408,7 @@ public class EnsRegistry(
             override fun decode(log: Log): NewTTL? = super.decode(log)
 
             @JvmStatic
-            override fun decode(log: Log, `data`: List<Any>): NewTTL = NewTTL(data[0] as io.ethers.core.types.Bytes, data[1] as java.math.BigInteger, log)
+            override fun decode(log: Log, `data`: List<Any>): NewTTL = NewTTL(data[0] as io.ethers.core.types.Bytes, data[1] as io.github.artificialpb.bignum.BigInteger, log)
         }
     }
 

--- a/ethers-providers/build.gradle.kts
+++ b/ethers-providers/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
 
                 api(project(":ethers-core"))
                 api(project(":ethers-signers"))
+                api(libs.bignumkt)
 
                 implementation(project(":logger"))
                 implementation(libs.jctools)

--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/AnvilProvider.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/AnvilProvider.kt
@@ -11,7 +11,7 @@ import io.ethers.providers.bindings.AnvilInstance
 import io.ethers.providers.middleware.Middleware
 import io.ethers.providers.types.RpcCall
 import io.ethers.providers.types.RpcRequest
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Provider implementation for interacting with an [Anvil](https://book.getfoundry.sh/reference/anvil/) node.

--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/Provider.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/Provider.kt
@@ -56,7 +56,7 @@ import io.ethers.providers.types.RpcRequest
 import io.ethers.providers.types.RpcSubscribe
 import io.ethers.providers.types.RpcSubscribeCall
 import io.ethers.providers.types.SuppliedRpcRequest
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 @Suppress("MoveLambdaOutsideParentheses")
 class Provider(override val client: JsonRpcClient, override val chainId: Long) : Middleware {

--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/middleware/EthApi.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/middleware/EthApi.kt
@@ -25,7 +25,7 @@ import io.ethers.providers.types.FilterPoller
 import io.ethers.providers.types.PendingTransaction
 import io.ethers.providers.types.RpcRequest
 import io.ethers.providers.types.RpcSubscribe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 interface EthApi {
     /**

--- a/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/types/PendingTransactionTest.kt
+++ b/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/types/PendingTransactionTest.kt
@@ -16,7 +16,7 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.intellij.lang.annotations.Language
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import java.time.Duration
 
 class PendingTransactionTest : FunSpec({

--- a/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/types/PendingTransactionTest.kt
+++ b/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/types/PendingTransactionTest.kt
@@ -10,13 +10,13 @@ import io.ethers.core.types.Log
 import io.ethers.core.types.TransactionReceipt
 import io.ethers.core.types.transaction.TxType
 import io.ethers.providers.Provider
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.intellij.lang.annotations.Language
-import io.github.artificialpb.bignum.BigInteger
 import java.time.Duration
 
 class PendingTransactionTest : FunSpec({

--- a/ethers-rlp/build.gradle.kts
+++ b/ethers-rlp/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
     sourceSets {
         val jvmSharedMain by getting {
             dependencies {
+                api(libs.bignumkt)
                 implementation(libs.ditchoom.buffer)
             }
         }

--- a/ethers-rlp/src/jvmSharedMain/kotlin/io/ethers/rlp/RlpDecoder.kt
+++ b/ethers-rlp/src/jvmSharedMain/kotlin/io/ethers/rlp/RlpDecoder.kt
@@ -1,6 +1,6 @@
 package io.ethers.rlp
 
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract

--- a/ethers-rlp/src/jvmSharedMain/kotlin/io/ethers/rlp/RlpEncoder.kt
+++ b/ethers-rlp/src/jvmSharedMain/kotlin/io/ethers/rlp/RlpEncoder.kt
@@ -3,7 +3,7 @@ package io.ethers.rlp
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.PlatformBuffer
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import kotlin.math.max
 
 /**

--- a/ethers-rlp/src/jvmSharedTest/kotlin/io/ethers/rlp/RlpDecoderTest.kt
+++ b/ethers-rlp/src/jvmSharedTest/kotlin/io/ethers/rlp/RlpDecoderTest.kt
@@ -1,11 +1,11 @@
 package io.ethers.rlp
 
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 
 class RlpDecoderTest : FunSpec({
     context("decode - BigInteger") {

--- a/ethers-rlp/src/jvmSharedTest/kotlin/io/ethers/rlp/RlpDecoderTest.kt
+++ b/ethers-rlp/src/jvmSharedTest/kotlin/io/ethers/rlp/RlpDecoderTest.kt
@@ -5,7 +5,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class RlpDecoderTest : FunSpec({
     context("decode - BigInteger") {

--- a/ethers-rlp/src/jvmSharedTest/kotlin/io/ethers/rlp/RlpEncoderTest.kt
+++ b/ethers-rlp/src/jvmSharedTest/kotlin/io/ethers/rlp/RlpEncoderTest.kt
@@ -1,10 +1,10 @@
 package io.ethers.rlp
 
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
-import io.github.artificialpb.bignum.BigInteger
 
 class RlpEncoderTest : FunSpec({
     test("fail if exact size of encoder is invalid") {

--- a/ethers-rlp/src/jvmSharedTest/kotlin/io/ethers/rlp/RlpEncoderTest.kt
+++ b/ethers-rlp/src/jvmSharedTest/kotlin/io/ethers/rlp/RlpEncoderTest.kt
@@ -4,7 +4,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 class RlpEncoderTest : FunSpec({
     test("fail if exact size of encoder is invalid") {

--- a/ethers-signers-gcp/src/jvmSharedTest/kotlin/io/ethers/signers/GcpSignerTest.kt
+++ b/ethers-signers-gcp/src/jvmSharedTest/kotlin/io/ethers/signers/GcpSignerTest.kt
@@ -16,13 +16,13 @@ import io.ethers.core.isFailure
 import io.ethers.core.isSuccess
 import io.ethers.core.types.Address
 import io.ethers.crypto.Secp256k1
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import io.github.artificialpb.bignum.BigInteger
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 

--- a/ethers-signers-gcp/src/jvmSharedTest/kotlin/io/ethers/signers/GcpSignerTest.kt
+++ b/ethers-signers-gcp/src/jvmSharedTest/kotlin/io/ethers/signers/GcpSignerTest.kt
@@ -22,7 +22,7 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 

--- a/ethers-signers/build.gradle.kts
+++ b/ethers-signers/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
             dependencies {
                 api(project(":ethers-core"))
                 api(project(":ethers-crypto"))
+                api(libs.bignumkt)
             }
         }
 

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
         val jvmSharedMain by getting {
             dependencies {
                 implementation(libs.kotlinx.cli)
+                implementation(libs.bignumkt)
                 runtimeOnly(libs.bundles.log4j2)
 
                 implementation(project.dependencies.platform(libs.ethers.bom))

--- a/examples/src/jvmSharedMain/kotlin/io/ethers/examples/UniswapV2FeeFinder.kt
+++ b/examples/src/jvmSharedMain/kotlin/io/ethers/examples/UniswapV2FeeFinder.kt
@@ -9,7 +9,7 @@ import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
 import kotlinx.cli.required
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Calculate Uniswap V2 pool fees. The fees are hardcoded, but we can calculate it by:

--- a/examples/src/jvmSharedMain/kotlin/io/ethers/examples/UniswapV2FeeFinder.kt
+++ b/examples/src/jvmSharedMain/kotlin/io/ethers/examples/UniswapV2FeeFinder.kt
@@ -5,11 +5,11 @@ import io.ethers.core.types.BlockId
 import io.ethers.examples.UniswapV2FeeFinder.Companion.getFeePercent
 import io.ethers.examples.gen.UniswapV2Pair
 import io.ethers.providers.Provider
+import io.github.artificialpb.bignum.BigInteger
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
 import kotlinx.cli.required
-import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Calculate Uniswap V2 pool fees. The fees are hardcoded, but we can calculate it by:

--- a/examples/src/jvmSharedMain/kotlin/io/ethers/examples/abi/TransferERC20.kt
+++ b/examples/src/jvmSharedMain/kotlin/io/ethers/examples/abi/TransferERC20.kt
@@ -4,11 +4,11 @@ import io.ethers.core.types.Address
 import io.ethers.examples.gen.ERC20
 import io.ethers.providers.Provider
 import io.ethers.signers.PrivateKeySigner
+import io.github.artificialpb.bignum.BigInteger
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
 import kotlinx.cli.required
-import io.github.artificialpb.bignum.BigInteger
 import java.time.Duration
 
 /**

--- a/examples/src/jvmSharedMain/kotlin/io/ethers/examples/abi/TransferERC20.kt
+++ b/examples/src/jvmSharedMain/kotlin/io/ethers/examples/abi/TransferERC20.kt
@@ -8,7 +8,7 @@ import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
 import kotlinx.cli.required
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import java.time.Duration
 
 /**

--- a/examples/src/jvmSharedMain/kotlin/io/ethers/examples/balancetracker/BalanceTracker.kt
+++ b/examples/src/jvmSharedMain/kotlin/io/ethers/examples/balancetracker/BalanceTracker.kt
@@ -9,7 +9,7 @@ import io.ethers.providers.types.unwrap
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Monitoring of ETH balance and balance of list of ERC20 tokens for a given address, using manual request batching.

--- a/examples/src/jvmSharedMain/kotlin/io/ethers/examples/balancetracker/BalanceTracker.kt
+++ b/examples/src/jvmSharedMain/kotlin/io/ethers/examples/balancetracker/BalanceTracker.kt
@@ -6,10 +6,10 @@ import io.ethers.examples.gen.ERC20
 import io.ethers.providers.Provider
 import io.ethers.providers.types.sendAwait
 import io.ethers.providers.types.unwrap
+import io.github.artificialpb.bignum.BigInteger
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
-import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Monitoring of ETH balance and balance of list of ERC20 tokens for a given address, using manual request batching.

--- a/examples/src/jvmSharedMain/kotlin/io/ethers/examples/batchrequests/BatchRequests.kt
+++ b/examples/src/jvmSharedMain/kotlin/io/ethers/examples/batchrequests/BatchRequests.kt
@@ -8,10 +8,10 @@ import io.ethers.providers.types.BatchRpcRequest
 import io.ethers.providers.types.await
 import io.ethers.providers.types.batchRequest
 import io.ethers.providers.types.unwrap
+import io.github.artificialpb.bignum.BigDecimal
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
-import io.github.artificialpb.bignum.BigDecimal
 
 /**
  * Request batching of pool reserves on different DEXes for WETH / USDC pair and calculating WETH price,

--- a/examples/src/jvmSharedMain/kotlin/io/ethers/examples/batchrequests/BatchRequests.kt
+++ b/examples/src/jvmSharedMain/kotlin/io/ethers/examples/batchrequests/BatchRequests.kt
@@ -11,7 +11,7 @@ import io.ethers.providers.types.unwrap
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
-import java.math.BigDecimal
+import io.github.artificialpb.bignum.BigDecimal
 
 /**
  * Request batching of pool reserves on different DEXes for WETH / USDC pair and calculating WETH price,

--- a/examples/src/jvmSharedMain/kotlin/io/ethers/examples/batchrequests/Multicall.kt
+++ b/examples/src/jvmSharedMain/kotlin/io/ethers/examples/batchrequests/Multicall.kt
@@ -6,10 +6,10 @@ import io.ethers.core.types.Address
 import io.ethers.core.types.BlockId
 import io.ethers.examples.gen.ERC20
 import io.ethers.providers.Provider
+import io.github.artificialpb.bignum.BigInteger
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
-import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Multicall example demonstrates how to aggregate multiple contract calls into Multicall3.

--- a/examples/src/jvmSharedMain/kotlin/io/ethers/examples/batchrequests/Multicall.kt
+++ b/examples/src/jvmSharedMain/kotlin/io/ethers/examples/batchrequests/Multicall.kt
@@ -9,7 +9,7 @@ import io.ethers.providers.Provider
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Multicall example demonstrates how to aggregate multiple contract calls into Multicall3.

--- a/examples/src/jvmSharedMain/kotlin/io/ethers/examples/eip712/EIP712SeaportOrderSigning.kt
+++ b/examples/src/jvmSharedMain/kotlin/io/ethers/examples/eip712/EIP712SeaportOrderSigning.kt
@@ -11,10 +11,10 @@ import io.ethers.examples.gen.Seaport_1_6
 import io.ethers.providers.Provider
 import io.ethers.signers.PrivateKeySigner
 import io.ethers.signers.Signer
+import io.github.artificialpb.bignum.BigInteger
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
-import io.github.artificialpb.bignum.BigInteger
 import kotlin.system.exitProcess
 
 /**

--- a/examples/src/jvmSharedMain/kotlin/io/ethers/examples/eip712/EIP712SeaportOrderSigning.kt
+++ b/examples/src/jvmSharedMain/kotlin/io/ethers/examples/eip712/EIP712SeaportOrderSigning.kt
@@ -14,7 +14,7 @@ import io.ethers.signers.Signer
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 import kotlin.system.exitProcess
 
 /**

--- a/examples/src/jvmSharedMain/kotlin/io/ethers/examples/tokenswapwitheventlistening/TokenSwapWithEventListening.kt
+++ b/examples/src/jvmSharedMain/kotlin/io/ethers/examples/tokenswapwitheventlistening/TokenSwapWithEventListening.kt
@@ -7,11 +7,11 @@ import io.ethers.examples.gen.UniswapV2Pair
 import io.ethers.examples.gen.UniswapV2Router02
 import io.ethers.providers.Provider
 import io.ethers.signers.PrivateKeySigner
+import io.github.artificialpb.bignum.BigInteger
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
 import kotlinx.cli.required
-import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Uniswap V2 ETH to ERC20 swap with listening to UniswapV2Pair Sync event

--- a/examples/src/jvmSharedMain/kotlin/io/ethers/examples/tokenswapwitheventlistening/TokenSwapWithEventListening.kt
+++ b/examples/src/jvmSharedMain/kotlin/io/ethers/examples/tokenswapwitheventlistening/TokenSwapWithEventListening.kt
@@ -11,7 +11,7 @@ import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
 import kotlinx.cli.required
-import java.math.BigInteger
+import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Uniswap V2 ETH to ERC20 swap with listening to UniswapV2Pair Sync event

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ cryptography = "0.6.0"
 ditchoom-buffer = "4.2.2"
 dokka = "2.2.0"
 agp = "9.1.0"
+bignumkt = "0.1.0-SNAPSHOT"
 
 [libraries]
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
@@ -75,6 +76,7 @@ whyoleg-cryptography-asn1 = { module = "dev.whyoleg.cryptography:cryptography-se
 gcp-kms = { module = "com.google.cloud:google-cloud-kms", version = "2.94.0" }
 
 ditchoom-buffer = { module = "com.ditchoom:buffer", version.ref = "ditchoom-buffer" }
+bignumkt = { module = "io.github.artificialpb:bignum", version.ref = "bignumkt" }
 
 
 kotlinx-cli = { module = "org.jetbrains.kotlinx:kotlinx-cli", version = "0.3.6" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ cryptography = "0.6.0"
 ditchoom-buffer = "4.2.2"
 dokka = "2.2.0"
 agp = "9.1.0"
-bignumkt = "0.1.0-SNAPSHOT"
+bignumkt = "1.0.0"
 
 [libraries]
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary

- Add the Bignum KT snapshot dependency and Central Portal snapshot repository.
- Replace direct `java.math.BigInteger` / `BigDecimal` imports with Bignum KT types across production and test sources.
- Update abigen and generated ENS wrappers so contract APIs use `io.github.artificialpb.bignum` imports.

## Impact

This keeps the current JVM and Android behavior through Bignum KT's JVM/Android typealiases while moving public big-number APIs to the multiplatform library package.

## Validation

- `./gradlew :ethers-rlp:compileKotlinJvm :ethers-core:compileKotlinJvm :ethers-crypto:compileKotlinJvm :ethers-abi:compileKotlinJvm :ethers-providers:compileKotlinJvm :ethers-signers:compileKotlinJvm :ethers-signers-gcp:compileKotlinJvm :ethers-abigen:compileKotlinJvm :ethers-ens:compileKotlinJvm :examples:compileKotlinJvm`
- `./gradlew :ethers-rlp:jvmKotest :ethers-core:jvmKotest :ethers-crypto:jvmKotest :ethers-abi:jvmKotest :ethers-abigen:jvmKotest :ethers-ens:jvmKotest :ethers-signers:jvmKotest :ethers-signers-gcp:jvmKotest`
- `./gradlew :ethers-abigen:compileAndroidMain :ethers-ens:compileAndroidMain :examples:compileAndroidMain :ethers-abigen:compileJvmSharedMainKotlinMetadata :ethers-ens:compileJvmSharedMainKotlinMetadata :examples:compileJvmSharedMainKotlinMetadata`