### PR TITLE
fix: kotlinx default Tracer deserialization

### DIFF
--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/HexSerializers.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/HexSerializers.kt
@@ -1,12 +1,12 @@
 package io.ethers.core
 
+import io.github.artificialpb.bignum.BigInteger
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import io.github.artificialpb.bignum.BigInteger
 
 /**
  * Field-level [KSerializer] that encodes a [Long] as a 0x-prefixed hex string and decodes

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/JsonElementExtensions.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/JsonElementExtensions.kt
@@ -4,6 +4,7 @@ import io.ethers.core.types.Address
 import io.ethers.core.types.Bloom
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Hash
+import io.github.artificialpb.bignum.BigInteger
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
@@ -13,7 +14,6 @@ import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.double
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
-import io.github.artificialpb.bignum.BigInteger
 
 private val EMPTY_BYTES = ByteArray(0)
 

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/JsonValueConverters.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/JsonValueConverters.kt
@@ -1,0 +1,39 @@
+package io.ethers.core
+
+import io.github.artificialpb.bignum.BigDecimal
+import io.github.artificialpb.bignum.BigInteger
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.serializerOrNull
+
+@Suppress("UNCHECKED_CAST")
+fun Any?.toJsonElement(): JsonElement = when (this) {
+    null -> JsonNull
+    is JsonElement -> this
+    is String -> JsonPrimitive(this)
+    is Boolean -> JsonPrimitive(this)
+    is Byte -> JsonPrimitive(this)
+    is Short -> JsonPrimitive(this)
+    is Int -> JsonPrimitive(this)
+    is Long -> JsonPrimitive(this)
+    is Float -> JsonPrimitive(this)
+    is Double -> JsonPrimitive(this)
+    is BigInteger -> JsonPrimitive(this.toString())
+    is BigDecimal -> JsonPrimitive(this.toString())
+    is ByteArray -> JsonPrimitive(FastHex.encodeWithPrefix(this))
+    is Array<*> -> JsonArray(this.map { it.toJsonElement() })
+    is Iterable<*> -> JsonArray(this.map { it.toJsonElement() })
+    is Map<*, *> -> JsonObject(this.entries.associate { (k, v) -> k.toString() to v.toJsonElement() })
+    else -> {
+        val ser = serializerOrNull(this::class.java)
+            ?: throw IllegalArgumentException(
+                "Cannot serialize JSON value of type ${this::class.java.name}: " +
+                    "no kotlinx @Serializable serializer is registered. " +
+                    "Convert it manually or pass a JsonElement.",
+            )
+        Kotlinx.DEFAULT.encodeToJsonElement(ser, this)
+    }
+}

--- a/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/tracers/Tracer.kt
+++ b/ethers-core/src/jvmSharedMain/kotlin/io/ethers/core/types/tracers/Tracer.kt
@@ -1,6 +1,7 @@
 package io.ethers.core.types.tracers
 
 import io.ethers.core.FastHex
+import io.ethers.core.toJsonElement
 import io.ethers.core.types.BlockOverride
 import io.ethers.core.types.BlockOverrideSerializer
 import io.ethers.core.types.StateOverride
@@ -13,10 +14,9 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonEncoder
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import kotlinx.serialization.serializer
 import kotlin.reflect.KClass
 
 /**
@@ -71,7 +71,10 @@ sealed interface AnyTracer<T : Any> {
      * Default implementation uses [resultType] for simple deserialization via kotlinx.serialization.
      * Override for custom decoding logic (e.g., MuxTracer).
      */
-    fun decodeResult(json: Json, element: JsonElement): T = throw UnsupportedOperationException("Override decodeResult in ${this::class.simpleName}")
+    @Suppress("UNCHECKED_CAST")
+    fun decodeResult(json: Json, element: JsonElement): T {
+        return json.decodeFromJsonElement(serializer(resultType.java), element) as T
+    }
 }
 
 @Serializable(with = TracerConfigSerializer::class)
@@ -94,12 +97,12 @@ object TracerConfigSerializer : KSerializer<TracerConfig<*>> {
                 when (val tracer = value.tracer) {
                     is Tracer<*> -> {
                         put("tracer", tracer.name)
-                        put("tracerConfig", mapToJsonElement(tracer.config))
+                        put("tracerConfig", tracer.config.toJsonElement())
                     }
 
                     else -> {
                         for ((fieldName, fieldValue) in tracer.config) {
-                            put(fieldName, anyToJsonElement(fieldValue))
+                            put(fieldName, fieldValue.toJsonElement())
                         }
                     }
                 }
@@ -124,29 +127,4 @@ object TracerConfigSerializer : KSerializer<TracerConfig<*>> {
     }
 
     override fun deserialize(decoder: Decoder): TracerConfig<*> = throw UnsupportedOperationException()
-}
-
-internal fun mapToJsonElement(map: Map<String, Any?>): kotlinx.serialization.json.JsonObject {
-    return buildJsonObject {
-        for ((k, v) in map) {
-            put(k, anyToJsonElement(v))
-        }
-    }
-}
-
-private fun anyToJsonElement(value: Any?): JsonElement {
-    return when (value) {
-        null -> JsonNull
-        is Boolean -> JsonPrimitive(value)
-        is String -> JsonPrimitive(value)
-        is Int -> JsonPrimitive(value)
-        is Long -> JsonPrimitive(value)
-        is Double -> JsonPrimitive(value)
-        is Float -> JsonPrimitive(value)
-        is Map<*, *> -> {
-            @Suppress("UNCHECKED_CAST")
-            mapToJsonElement(value as Map<String, Any?>)
-        }
-        else -> JsonPrimitive(value.toString())
-    }
 }

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/JsonElementExtensionsTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/JsonElementExtensionsTest.kt
@@ -4,13 +4,13 @@ import io.ethers.core.types.Address
 import io.ethers.core.types.Bloom
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Hash
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonPrimitive
-import io.github.artificialpb.bignum.BigInteger
 
 class JsonElementExtensionsTest : FunSpec({
     context("asHexByteArray") {

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/AccountOverrideTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/AccountOverrideTest.kt
@@ -1,7 +1,7 @@
 package io.ethers.core.types
 
-import io.github.artificialpb.bignum.BigInteger
 import io.ethers.core.Kotlinx
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.FunSpec

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/BlockOverrideTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/BlockOverrideTest.kt
@@ -1,7 +1,7 @@
 package io.ethers.core.types
 
-import io.github.artificialpb.bignum.BigInteger
 import io.ethers.core.Kotlinx
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/BytesTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/BytesTest.kt
@@ -1,7 +1,7 @@
 package io.ethers.core.types
 
-import io.github.artificialpb.bignum.BigInteger
 import io.ethers.core.Kotlinx
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/FeeHistoryTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/FeeHistoryTest.kt
@@ -1,7 +1,7 @@
 package io.ethers.core.types
 
-import io.github.artificialpb.bignum.BigInteger
 import io.ethers.core.Kotlinx
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import org.intellij.lang.annotations.Language

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/HashTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/HashTest.kt
@@ -1,8 +1,8 @@
 package io.ethers.core.types
 
 import io.ethers.core.FastHex
-import io.github.artificialpb.bignum.BigInteger
 import io.ethers.core.Kotlinx
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData

--- a/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/tracers/TracerTest.kt
+++ b/ethers-core/src/jvmSharedTest/kotlin/io/ethers/core/types/tracers/TracerTest.kt
@@ -8,6 +8,26 @@ import io.ethers.core.types.StateOverride
 import io.ethers.core.types.StateOverrideSerializer
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+import kotlin.reflect.KClass
+
+private object CustomDefaultDecodeTracer : Tracer<CustomDefaultDecodeResult> {
+    override val name: String = "customDefaultDecodeTracer"
+    override val resultType: KClass<CustomDefaultDecodeResult> = CustomDefaultDecodeResult::class
+    override val config: Map<String, Any?> = mapOf(
+        "enabled" to true,
+        "steps" to listOf(1, 2, 3),
+        "nested" to mapOf("labels" to arrayOf("alpha", "beta")),
+        "payload" to byteArrayOf(0xde.toByte(), 0xad.toByte()),
+    )
+}
+
+@Serializable
+private data class CustomDefaultDecodeResult(
+    val data: String,
+    val count: Int,
+)
 
 class TracerTest : FunSpec({
     context("config serialization") {
@@ -82,6 +102,33 @@ class TracerTest : FunSpec({
                   "blockOverrides": ${Kotlinx.DEFAULT.encodeToString(config.blockOverrides!!)}
                 }
             """
+        }
+
+        test("custom tracer config serializes nested JSON-like values") {
+            Kotlinx.DEFAULT.encodeToString(TracerConfig(CustomDefaultDecodeTracer)) shouldEqualJson """
+                {
+                  "tracer": "customDefaultDecodeTracer",
+                  "tracerConfig": {
+                    "enabled": true,
+                    "steps": [1, 2, 3],
+                    "nested": {
+                      "labels": ["alpha", "beta"]
+                    },
+                    "payload": "0xdead"
+                  }
+                }
+            """
+        }
+    }
+
+    context("result deserialization") {
+        test("custom tracer can rely on default resultType decoder") {
+            val result = CustomDefaultDecodeTracer.decodeResult(
+                Kotlinx.DEFAULT,
+                Kotlinx.DEFAULT.parseToJsonElement("""{"data":"ok","count":2}"""),
+            )
+
+            result shouldBe CustomDefaultDecodeResult("ok", 2)
         }
     }
 })

--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/JsonRpcClient.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/JsonRpcClient.kt
@@ -5,20 +5,16 @@ import io.ethers.core.FastHex
 import io.ethers.core.Kotlinx
 import io.ethers.core.Result
 import io.ethers.core.json.JsonElement
+import io.ethers.core.toJsonElement
 import io.ethers.providers.types.BatchRpcRequest
-import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.serializer
-import kotlinx.serialization.serializerOrNull
-import io.github.artificialpb.bignum.BigInteger
 import okhttp3.OkHttpClient
-import java.math.BigDecimal
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import kotlinx.serialization.json.JsonElement as KJsonElement
@@ -128,43 +124,7 @@ internal fun buildJsonRpcRequest(method: String, id: Long, params: Array<*>): St
  * via the kotlinx `@Serializable` contract and fail fast if no serializer is registered,
  * rather than silently producing an unusable payload.
  */
-@Suppress("UNCHECKED_CAST")
-internal fun Any?.toParamJsonElement(): KJsonElement = when (this) {
-    null -> JsonNull
-    is KJsonElement -> this
-    is String -> JsonPrimitive(this)
-    is Boolean -> JsonPrimitive(this)
-    is Byte -> JsonPrimitive(this)
-    is Short -> JsonPrimitive(this)
-    is Int -> JsonPrimitive(this)
-    is Long -> JsonPrimitive(this)
-    is Float -> JsonPrimitive(this)
-    is Double -> JsonPrimitive(this)
-    is BigInteger -> JsonPrimitive(this.toString())
-    is BigDecimal -> JsonPrimitive(this)
-    // ByteArray must be checked before Array<*> — `byte[]` is a primitive array on the JVM
-    // and would otherwise fall into the reflective branch with no useful serializer.
-    is ByteArray -> JsonPrimitive(FastHex.encodeWithPrefix(this))
-    is Array<*> -> JsonArray(this.map { it.toParamJsonElement() })
-    // Iterable covers List, Set and any other Kotlin collection a caller might pass.
-    is Iterable<*> -> JsonArray(this.map { it.toParamJsonElement() })
-    // Explicit Map handling is required: `serializer(LinkedHashMap::class.java)` loses the
-    // generic key/value serializers and can't encode nested @Serializable values such as
-    // Address or Bytes. Keys are stringified, matching Jackson's behavior.
-    is Map<*, *> -> JsonObject(this.entries.associate { (k, v) -> k.toString() to v.toParamJsonElement() })
-    else -> {
-        // Fallback for @Serializable types (Address, Hash, Bytes, CallRequest, …).
-        // Use `serializerOrNull` so unknown types fail with a clear error instead of throwing
-        // a confusing SerializationException from deep inside kotlinx reflection.
-        val ser = serializerOrNull(this::class.java)
-            ?: throw IllegalArgumentException(
-                "Cannot serialize JSON-RPC parameter of type ${this::class.java.name}: " +
-                    "no kotlinx @Serializable serializer is registered. " +
-                    "Convert it manually or pass a JsonElement.",
-            )
-        Kotlinx.DEFAULT.encodeToJsonElement(ser, this)
-    }
-}
+internal fun Any?.toParamJsonElement(): KJsonElement = toJsonElement()
 
 /**
  * Internal JSON-RPC error, returned when the RPC call fails.

--- a/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/HttpClientTest.kt
+++ b/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/HttpClientTest.kt
@@ -4,6 +4,7 @@ import io.ethers.core.Kotlinx
 import io.ethers.core.isFailure
 import io.ethers.core.isSuccess
 import io.ethers.core.types.Address
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.funSpec
@@ -17,7 +18,6 @@ import kotlinx.serialization.json.long
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import org.intellij.lang.annotations.Language
-import io.github.artificialpb.bignum.BigInteger
 import kotlinx.serialization.json.JsonElement as KJsonElement
 
 /**

--- a/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/WsClientTest.kt
+++ b/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/WsClientTest.kt
@@ -3,6 +3,7 @@ package io.ethers.providers
 import io.ethers.core.Kotlinx
 import io.ethers.core.isSuccess
 import io.ethers.core.types.Address
+import io.github.artificialpb.bignum.BigInteger
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -14,7 +15,6 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
 import okhttp3.OkHttpClient
 import org.intellij.lang.annotations.Language
-import io.github.artificialpb.bignum.BigInteger
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.json.JsonElement as KJsonElement


### PR DESCRIPTION
## Summary

Fixes two regressions from the Jackson to kotlinx serialization migration:

- Restores the default `AnyTracer.decodeResult` path so custom tracers can decode result payloads through their declared `resultType`.
- Replaces lossy `toString()` JSON conversion with a shared `Any?.toJsonElement()` converter that handles JSON-like structures, byte arrays, bignums, and registered `@Serializable` values.
- Reuses the shared converter for JSON-RPC params so provider request serialization and tracer config serialization stay aligned.
- Adds regression coverage for nested custom tracer config values and default custom tracer result decoding.

## Root Cause

The migration removed Jackson's reflective fallback for custom tracer result decoding and introduced a local config converter that silently serialized unsupported values as strings. That changed behavior for custom tracers and could turn array/list config fields into invalid JSON strings.

## Validation

- `./gradlew :ethers-core:kotest`
- `./gradlew :ethers-providers:compileKotlinJvm`
- `./gradlew ktlintFormat`
- `./gradlew :ethers-core:ktlintCheck :ethers-providers:ktlintCheck`
- `git diff --check`