### PR TITLE
feat: generate BIP39 test vectors as static data

### DIFF
--- a/buildSrc/src/main/kotlin/static-data-generator.gradle.kts
+++ b/buildSrc/src/main/kotlin/static-data-generator.gradle.kts
@@ -40,6 +40,7 @@ abstract class StaticDataConfig(val configName: String) : Named {
     abstract val inputFile: RegularFileProperty
     abstract val packageName: Property<String>
     abstract val propertyName: Property<String>
+    abstract val sourceSetName: Property<String>
 
     internal var dataProvider: ((File) -> JsonNode)? = null
 
@@ -336,20 +337,20 @@ abstract class GenerateStaticDataTask : DefaultTask() {
 // Register the extension
 val extension = extensions.create<StaticDataGeneratorExtension>("staticDataGenerator")
 
-// Configure the output directory
-val generatedSourceDir = layout.buildDirectory.dir("generated/source/staticData/main/kotlin")
-
 // Create tasks and wire source sets after evaluation
 afterEvaluate {
     extension.generators.forEach { config ->
         val taskName = "generate${config.name.replaceFirstChar { it.uppercase() }}StaticData"
+        val sourceSetName = config.sourceSetName.getOrElse("commonMain")
 
         val task = tasks.register<GenerateStaticDataTask>(taskName) {
             inputFile.set(config.inputFile)
             packageName.set(config.packageName)
             objectName.set(config.deriveObjectName())
             propertyName.set(config.propertyName)
-            outputDir.set(generatedSourceDir)
+            outputDir.set(
+                layout.buildDirectory.dir("generated/source/staticData/$sourceSetName/${config.name}/kotlin"),
+            )
             dataProvider = config.dataProvider
         }
 
@@ -357,7 +358,7 @@ afterEvaluate {
         // for all consuming tasks (compileKotlin, sourcesJar, ktlint, etc.)
         pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
             val kotlin = extensions.getByType<KotlinMultiplatformExtension>()
-            kotlin.sourceSets.getByName("commonMain").kotlin.srcDir(task)
+            kotlin.sourceSets.getByName(sourceSetName).kotlin.srcDir(task)
         }
     }
 }

--- a/ethers-crypto/build.gradle.kts
+++ b/ethers-crypto/build.gradle.kts
@@ -18,6 +18,16 @@ staticDataGenerator {
                 ObjectMapper().valueToTree(words)
             }
         }
+
+        create("bip39EnglishTestVectors") {
+            inputFile.set(file("src/jvmSharedTest/resources/bip39/wordlist_english_test_vector.json"))
+            packageName.set("io.ethers.crypto.bip39")
+            propertyName.set("VECTORS")
+            sourceSetName.set("commonTest")
+            data { file ->
+                ObjectMapper().readTree(file)
+            }
+        }
     }
 }
 
@@ -51,7 +61,6 @@ kotlin {
         val jvmSharedTest by getting {
             dependencies {
                 implementation(libs.bundles.kotest)
-                implementation(libs.bundles.jackson)
             }
         }
     }

--- a/ethers-crypto/src/jvmSharedTest/kotlin/io/ethers/crypto/bip39/MnemonicCodeTest.kt
+++ b/ethers-crypto/src/jvmSharedTest/kotlin/io/ethers/crypto/bip39/MnemonicCodeTest.kt
@@ -1,7 +1,5 @@
 package io.ethers.crypto.bip39
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.json.JsonMapper
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAll
@@ -46,14 +44,8 @@ class MnemonicCodeTest : FunSpec({
     }
 
     context("test vectors") {
-        val mapper = JsonMapper.builder().build()
-
         test("english") {
-            val vectors = mapper.readerForListOf(TestVector::class.java).readValue<List<TestVector>>(
-                javaClass.getResource("/bip39/wordlist_english_test_vector.json").openStream(),
-            )
-
-            vectors.forAll { vector ->
+            Bip39EnglishTestVectorsData.VECTORS.forAll { vector ->
                 val mnemonic = MnemonicCode.fromEntropy(vector.entropy.hexToByteArray())
 
                 mnemonic.words shouldContainExactly vector.mnemonic.split(MnemonicWordListEnglish.separator)
@@ -62,12 +54,4 @@ class MnemonicCodeTest : FunSpec({
             }
         }
     }
-}) {
-    private data class TestVector(
-        @param:JsonProperty("entropy") val entropy: String,
-        @param:JsonProperty("mnemonic") val mnemonic: String,
-        @param:JsonProperty("passphrase") val passphrase: String,
-        @param:JsonProperty("seed") val seed: String,
-        @param:JsonProperty("bip32_xprv") val bip32Xprv: String,
-    )
-}
+})


### PR DESCRIPTION
## What changed

- Added source-set selection to the static data generator so generated data can target `commonTest`.
- Added a BIP39 English test vector static-data generator for `ethers-crypto`.
- Updated `MnemonicCodeTest` to use generated test vectors instead of loading/parsing a JVM resource with Jackson.

## Why

This removes the Jackson dependency from the `ethers-crypto` JVM test runtime and prepares the BIP39 mnemonic test for a future move into a common KMP test source set.

## Validation

- `./gradlew :ethers-crypto:jvmTest`
- `./gradlew :ethers-crypto:dependencyInsight --dependency jackson --configuration jvmTestRuntimeClasspath`