### PR TITLE
feat: migrate HTTP/WebSocket client from OkHttp to Ktor

### DIFF
--- a/ethers-ens/src/jvmSharedMain/kotlin/io/ethers/ens/EnsMiddleware.kt
+++ b/ethers-ens/src/jvmSharedMain/kotlin/io/ethers/ens/EnsMiddleware.kt
@@ -21,6 +21,7 @@ import io.ethers.logger.err
 import io.ethers.logger.getLogger
 import io.ethers.logger.wrn
 import io.ethers.providers.middleware.Middleware
+import io.github.artificialpb.bignum.BigInteger
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.request.get
 import io.ktor.client.request.post
@@ -31,7 +32,6 @@ import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
-import java.math.BigInteger
 import java.util.concurrent.CompletableFuture
 import io.ktor.client.HttpClient as KtorHttpClient
 
@@ -154,7 +154,8 @@ class EnsMiddleware @JvmOverloads constructor(
         // Unwrap resolver from RpcResponse and call its addr() function.
         // If RpcResponse is an error, map it to error FailedToResolve.
         val resolver = resolverResponse.unwrap()
-        val supportsWildcard = resolver.supportsInterface(ENSIP_10_INTERFACE_ID).call(BlockId.LATEST).sendAwait()
+        val supportsWildcard =
+            resolver.supportsInterface(ENSIP_10_INTERFACE_ID).call(BlockId.LATEST).sendAwait()
 
         // add nodehash as first parameter, because it is present in all resolutions
         parameters.add(0, Bytes(nameHash))
@@ -168,12 +169,16 @@ class EnsMiddleware @JvmOverloads constructor(
                 .sendAwait()
 
             // try to decode OffchainLookup error
-            val resolveLookupRevert = resolveResult.unwrapErrorOrNull()?.asTypeOrNull<ExtendedResolver.OffchainLookup>()
+            val resolveLookupRevert =
+                resolveResult.unwrapErrorOrNull()?.asTypeOrNull<ExtendedResolver.OffchainLookup>()
 
             return if (resolveLookupRevert == null) {
                 // result is resolved ens name
                 resolveResult.mapError {
-                    Error.FailedToResolve("Failed to resolve ens name: $ensName with resolver ${resolver.address}.", it)
+                    Error.FailedToResolve(
+                        "Failed to resolve ens name: $ensName with resolver ${resolver.address}.",
+                        it,
+                    )
                 }
             } else {
                 // result is OffchainLookup error
@@ -192,7 +197,12 @@ class EnsMiddleware @JvmOverloads constructor(
                 resolver.supportsInterface(abiFunction.selector).call(BlockId.LATEST).sendAwait()
 
             if (!supportsFunction.unwrapElse(false)) {
-                return failure(Error.UnsupportedSelector(resolver.address, abiFunction.selector.toString()))
+                return failure(
+                    Error.UnsupportedSelector(
+                        resolver.address,
+                        abiFunction.selector.toString(),
+                    ),
+                )
             }
 
             // create callback for corresponding function selector
@@ -214,9 +224,16 @@ class EnsMiddleware @JvmOverloads constructor(
                     // Return different errors on empty address and failure to resolve
                     // TODO - handle differently
                     val isAddrCall = abiFunction.selector == ExtendedResolver.FUNCTION_ADDR.selector
-                    if (isAddrCall && AbiCodec.decode(AbiType.Address, it.asByteArray()) == Address.ZERO) {
+                    if (isAddrCall && AbiCodec.decode(
+                            AbiType.Address,
+                            it.asByteArray(),
+                        ) == Address.ZERO
+                    ) {
                         return@andThen failure(
-                            Error.UnknownEnsName(resolver.address, FastHex.encodeWithPrefix(nameHash)),
+                            Error.UnknownEnsName(
+                                resolver.address,
+                                FastHex.encodeWithPrefix(nameHash),
+                            ),
                         )
                     }
 
@@ -245,7 +262,12 @@ class EnsMiddleware @JvmOverloads constructor(
 
         val address = registryContract.resolver(Bytes(nameHash))
             .call(BlockId.LATEST)
-            .mapError<Error> { Error.ResolvingResolver(registryAddress, FastHex.encodeWithPrefix(nameHash)) }
+            .mapError<Error> {
+                Error.ResolvingResolver(
+                    registryAddress,
+                    FastHex.encodeWithPrefix(nameHash),
+                )
+            }
             .andThen { if (it == Address.ZERO) failure(Error.UnknownResolver) else success(it) }
             .sendAwait()
 
@@ -313,8 +335,17 @@ class EnsMiddleware @JvmOverloads constructor(
      * @param sender sender parameter of [ExtendedResolver.OffchainLookup] - replacing {sender} RPC call parameter
      * @param calldata calldata parameter of [ExtendedResolver.OffchainLookup] - replacing {data} RPC call parameter
      */
-    private fun httpCall(urls: List<String>, sender: Address, calldata: Bytes): Result<Bytes, Error> {
-        if (urls.isEmpty()) return failure(Error.CcipCallFailed("No urls to resolve ens name!", null))
+    private fun httpCall(
+        urls: List<String>,
+        sender: Address,
+        calldata: Bytes,
+    ): Result<Bytes, Error> {
+        if (urls.isEmpty()) return failure(
+            Error.CcipCallFailed(
+                "No urls to resolve ens name!",
+                null,
+            ),
+        )
 
         for (url in urls) {
             if (!url.contains("{sender}")) continue
@@ -327,7 +358,10 @@ class EnsMiddleware @JvmOverloads constructor(
                     runBlocking { httpClient.get(href) }
                 } else {
                     val requestDTO = EnsGatewayRequestDTO(calldata, sender.toString())
-                    val body = Kotlinx.DEFAULT.encodeToString(EnsGatewayRequestDTO.serializer(), requestDTO)
+                    val body = Kotlinx.DEFAULT.encodeToString(
+                        EnsGatewayRequestDTO.serializer(),
+                        requestDTO,
+                    )
                     runBlocking {
                         httpClient.post(href) {
                             contentType(ContentType.Application.Json)
@@ -342,7 +376,12 @@ class EnsMiddleware @JvmOverloads constructor(
             }
         }
 
-        return failure(Error.CcipCallFailed("All urls are invalid or got server response 5xx", null))
+        return failure(
+            Error.CcipCallFailed(
+                "All urls are invalid or got server response 5xx",
+                null,
+            ),
+        )
     }
 
     /**
@@ -358,12 +397,14 @@ class EnsMiddleware @JvmOverloads constructor(
         val code = response.status.value
         if (code in 200..299) {
             val text = runBlocking { response.bodyAsText() }
-            val gatewayRequestDTO = Kotlinx.DEFAULT.decodeFromString(EnsGatewayResponseDTO.serializer(), text)
+            val gatewayRequestDTO =
+                Kotlinx.DEFAULT.decodeFromString(EnsGatewayResponseDTO.serializer(), text)
             return success(gatewayRequestDTO.data)
         }
 
         return if (code in 400..499) {
-            val msg = "Received status code: $code during CCIP call (url: $url, error: ${response.status.description})"
+            val msg =
+                "Received status code: $code during CCIP call (url: $url, error: ${response.status.description})"
             LOG.err { msg }
             failure(Error.CcipCallFailed(msg, null))
         } else {
@@ -437,7 +478,8 @@ class EnsMiddleware @JvmOverloads constructor(
 
             AvatarNFTType.ERC1155 -> {
                 val nft = ERC1155(provider, nftToken.nftAddr)
-                val balanceRes = nft.balanceOf(ensOwner, nftToken.tokenId).call(BlockId.LATEST).sendAwait()
+                val balanceRes =
+                    nft.balanceOf(ensOwner, nftToken.tokenId).call(BlockId.LATEST).sendAwait()
 
                 if (balanceRes.isFailure()) {
                     return failure(
@@ -515,7 +557,10 @@ class EnsMiddleware @JvmOverloads constructor(
             success(metadataDTO.image)
         }.unwrapOrReturn {
             return failure(
-                Error.AvatarParsing("Error while execution metadata request for url: $metadataUri", it),
+                Error.AvatarParsing(
+                    "Error while execution metadata request for url: $metadataUri",
+                    it,
+                ),
             )
         }
     }
@@ -559,7 +604,12 @@ class EnsMiddleware @JvmOverloads constructor(
             return reverseResolver.name(Bytes(nameHash))
                 .call(BlockId.LATEST)
                 .sendAwait()
-                .mapError<Error> { Error.FailedToResolve("Failed to resolve ens name for address: $address", it) }
+                .mapError<Error> {
+                    Error.FailedToResolve(
+                        "Failed to resolve ens name for address: $address",
+                        it,
+                    )
+                }
                 .andThen { ensName ->
                     // Validate ENS name by "resolving the returned name and calling addr on the resolver, checking it matches the original Ethereum address"
                     resolveAddress(ensName).get().andThen { resolved ->

--- a/ethers-ens/src/jvmSharedMain/kotlin/io/ethers/ens/EnsMiddleware.kt
+++ b/ethers-ens/src/jvmSharedMain/kotlin/io/ethers/ens/EnsMiddleware.kt
@@ -21,20 +21,25 @@ import io.ethers.logger.err
 import io.ethers.logger.getLogger
 import io.ethers.logger.wrn
 import io.ethers.providers.middleware.Middleware
-import io.github.artificialpb.bignum.BigInteger
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.Response
+import java.math.BigInteger
 import java.util.concurrent.CompletableFuture
+import io.ktor.client.HttpClient as KtorHttpClient
 
 class EnsMiddleware @JvmOverloads constructor(
     provider: Middleware,
     private val registryAddress: Address,
     private val ccipLookupLimit: Int = 4,
-    private val httpClient: OkHttpClient = OkHttpClient(),
+    private val httpClient: KtorHttpClient = KtorHttpClient(CIO),
 ) : Middleware by provider {
     private val LOG = getLogger()
     private val registryContract = EnsRegistry(provider, registryAddress)
@@ -43,7 +48,7 @@ class EnsMiddleware @JvmOverloads constructor(
     constructor(
         provider: Middleware,
         ccipLookupLimit: Int = 4,
-        client: OkHttpClient = OkHttpClient(),
+        client: KtorHttpClient = KtorHttpClient(CIO),
     ) : this(
         provider,
         getRegistryAddressOrThrow(provider.chainId),
@@ -312,11 +317,25 @@ class EnsMiddleware @JvmOverloads constructor(
         if (urls.isEmpty()) return failure(Error.CcipCallFailed("No urls to resolve ens name!", null))
 
         for (url in urls) {
-            // If url is missing mandatory {sender} parameter, try next url
-            val request = buildCcipRequest(url, sender, calldata) ?: continue
+            if (!url.contains("{sender}")) continue
+
+            var href = url.replace("{sender}", sender.toString())
 
             return try {
-                httpClient.newCall(request).execute().use { handleCcipResponse(it, url) } ?: continue
+                val response = if (url.contains("{data}")) {
+                    href = href.replace("{data}", calldata.toString())
+                    runBlocking { httpClient.get(href) }
+                } else {
+                    val requestDTO = EnsGatewayRequestDTO(calldata, sender.toString())
+                    val body = Kotlinx.DEFAULT.encodeToString(EnsGatewayRequestDTO.serializer(), requestDTO)
+                    runBlocking {
+                        httpClient.post(href) {
+                            contentType(ContentType.Application.Json)
+                            setBody(body)
+                        }
+                    }
+                }
+                handleCcipResponse(response, href) ?: continue
             } catch (e: Exception) {
                 LOG.err(e) { e.message ?: "" }
                 failure(Error.CcipCallFailed("Unknown error", ExceptionalError(e)))
@@ -333,51 +352,23 @@ class EnsMiddleware @JvmOverloads constructor(
      * - has status code 5xx, return null and try another url, if present.
      */
     private fun handleCcipResponse(
-        response: Response,
+        response: HttpResponse,
         url: String,
     ): Result<Bytes, Error>? {
-        if (response.isSuccessful) {
-            val gatewayRequestDTO = Kotlinx.DEFAULT.decodeFromString(EnsGatewayResponseDTO.serializer(), response.body.string())
-
+        val code = response.status.value
+        if (code in 200..299) {
+            val text = runBlocking { response.bodyAsText() }
+            val gatewayRequestDTO = Kotlinx.DEFAULT.decodeFromString(EnsGatewayResponseDTO.serializer(), text)
             return success(gatewayRequestDTO.data)
         }
 
-        return if (response.code in 400..499) {
-            // 4xx - return an error and stop
-            val msg = "Received status code: ${response.code} during CCIP call (url: $url, error: ${response.message})"
+        return if (code in 400..499) {
+            val msg = "Received status code: $code during CCIP call (url: $url, error: ${response.status.description})"
             LOG.err { msg }
             failure(Error.CcipCallFailed(msg, null))
         } else {
-            // 5xx - server issue, try different url
-            LOG.wrn { "500 error during CCIP call: url: $url, error: ${response.message}" }
+            LOG.wrn { "500 error during CCIP call: url: $url, error: ${response.status.description}" }
             null
-        }
-    }
-
-    /**
-     * Builds CCIP-read [okhttp3.Request] from [url], [sender] and [calldata], where [sender] and [calldata]
-     * are RPC request parameters.
-     *
-     * If RPC url contains {data}, the request is GET, otherwise POST.
-     *
-     * If [url] is missing {sender} parameter, return null.
-     */
-    private fun buildCcipRequest(url: String, sender: Address, calldata: Bytes): Request? {
-        if (!url.contains("{sender}")) return null // skip this url
-
-        // URL expansion
-        var href = url.replace("{sender}", sender.toString())
-
-        return if (url.contains("{data}")) {
-            href = href.replace("{data}", calldata.toString())
-            Request.Builder().url(href).get().build()
-        } else {
-            val requestDTO = EnsGatewayRequestDTO(calldata, sender.toString())
-
-            Request.Builder().url(href)
-                .post(Kotlinx.DEFAULT.encodeToString(EnsGatewayRequestDTO.serializer(), requestDTO).toRequestBody(JSON_MEDIA_TYPE))
-                .addHeader("Content-Type", "application/json")
-                .build()
         }
     }
 
@@ -509,22 +500,19 @@ class EnsMiddleware @JvmOverloads constructor(
         }
 
         // Execute metadataUri request and extract "image" attribute
-        val request = Request.Builder().url(metadataUri).build()
         return runCatching {
-            httpClient.newCall(request).execute().use {
-                if (!it.isSuccessful) {
-                    return failure(
-                        Error.AvatarParsing(
-                            "Error on executing NFT metadata URL: $metadataUri for token: ${token.tokenId} of NFT: ${token.nftAddr} (${it.message})",
-                            null,
-                        ),
-                    )
-                }
-
-                val metadataDTO = Kotlinx.DEFAULT.decodeFromString(MetadataDTO.serializer(), it.body.string())
-
-                success(metadataDTO.image)
+            val response = runBlocking { httpClient.get(metadataUri) }
+            if (!response.status.value.let { it in 200..299 }) {
+                return failure(
+                    Error.AvatarParsing(
+                        "Error on executing NFT metadata URL: $metadataUri for token: ${token.tokenId} of NFT: ${token.nftAddr} (${response.status.description})",
+                        null,
+                    ),
+                )
             }
+            val text = runBlocking { response.bodyAsText() }
+            val metadataDTO = Kotlinx.DEFAULT.decodeFromString(MetadataDTO.serializer(), text)
+            success(metadataDTO.image)
         }.unwrapOrReturn {
             return failure(
                 Error.AvatarParsing("Error while execution metadata request for url: $metadataUri", it),
@@ -744,7 +732,6 @@ class EnsMiddleware @JvmOverloads constructor(
     companion object {
         private val ENSIP_10_INTERFACE_ID = Bytes("0x9061b923")
         private val CALLBACK_FUNCTION_PARAM_TYPES = listOf(AbiType.Bytes, AbiType.Bytes)
-        private val JSON_MEDIA_TYPE = "application/json".toMediaType()
         private const val ENS_DOMAIN_REVERSE_REGISTER = "addr.reverse"
         private const val IPFS_GATEWAY = "https://ipfs.io/ipfs/"
 

--- a/ethers-providers/build.gradle.kts
+++ b/ethers-providers/build.gradle.kts
@@ -7,7 +7,7 @@ kotlin {
     sourceSets {
         val jvmSharedMain by getting {
             dependencies {
-                api(libs.bundles.okhttp3)
+                api(libs.bundles.ktor.client)
                 api(libs.channelskt.core)
 
                 api(project(":ethers-core"))

--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/HttpClient.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/HttpClient.kt
@@ -10,25 +10,26 @@ import io.ethers.logger.err
 import io.ethers.logger.getLogger
 import io.ethers.logger.trc
 import io.ethers.providers.types.BatchRpcRequest
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
-import okhttp3.Call
-import okhttp3.Callback
-import okhttp3.Headers
-import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody
-import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.Response
-import java.io.IOException
 import java.util.concurrent.CompletableFuture
+import io.ktor.client.HttpClient as KtorHttpClient
 import kotlinx.serialization.json.JsonElement as KJsonElement
 
 /**
@@ -37,8 +38,8 @@ import kotlinx.serialization.json.JsonElement as KJsonElement
  */
 class HttpClient(
     url: String,
-    private val client: OkHttpClient,
-    headers: Map<String, String> = emptyMap(),
+    private val client: KtorHttpClient,
+    private val requestHeaders: Map<String, String> = emptyMap(),
 ) : JsonRpcClient {
     @JvmOverloads
     constructor(url: String, config: RpcClientConfig = RpcClientConfig()) : this(
@@ -48,9 +49,9 @@ class HttpClient(
     )
 
     private val LOG = getLogger()
-    private val httpUrl = url.toHttpUrl()
+    private val httpUrl = url
     private val requestId = atomic(1L)
-    private val headers = Headers.Builder().apply { headers.forEach { (k, v) -> add(k, v) } }.build()
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     override fun requestBatch(batch: BatchRpcRequest): CompletableFuture<Boolean> {
         batch.markAsSent()
@@ -61,61 +62,20 @@ class HttpClient(
 
         val ret = CompletableFuture<Boolean>()
 
-        val (body, requestIndexPerId) = batch.toRequestBody()
-        val call = client.newCall(Request.Builder().url(httpUrl).headers(headers).post(body).build())
+        val (json, requestIndexPerId) = batch.toRequestBody()
 
-        call.enqueue(object : Callback {
-            override fun onFailure(call: Call, e: IOException) {
-                LOG.err(e) { "Error sending batch request" }
-
-                val response = getResponseFromException(e)
-                for (i in batch.responses.indices) {
-                    batch.responses[i].complete(response)
+        scope.launch {
+            try {
+                val response = client.post(httpUrl) {
+                    contentType(ContentType.Application.Json)
+                    headers { requestHeaders.forEach { (k, v) -> append(k, v) } }
+                    setBody(json)
                 }
+                val text = response.bodyAsText()
+                LOG.trc { "Batch response: ${text.removeSuffix("\n")}" }
 
-                ret.complete(false)
-            }
-
-            override fun onResponse(call: Call, response: Response) {
-                response.use {
+                if (!response.status.value.let { it in 200..299 }) {
                     try {
-                        var text = it.body.string()
-                        LOG.trc { "Batch response: ${text.removeSuffix("\n")}" }
-
-                        if (!it.isSuccessful) {
-                            // first, try to decode a JSON response
-                            try {
-                                val parsed = Kotlinx.DEFAULT.parseToJsonElement(text)
-                                for (element in parsed.jsonArray) {
-                                    val obj = element.jsonObject
-                                    var index = -1
-                                    val result = obj.decodeNextResult { id ->
-                                        index = requestIndexPerId[id] ?: throw Exception("Invalid response ID: $id")
-                                        batch.requests[index].resultDecoder
-                                    }
-                                    batch.responses[index].complete(result)
-                                }
-                                ret.complete(true)
-                                return
-                            } catch (_: Exception) {
-                            }
-
-                            // second, if decoding fails, return the response as a message and complete all requests
-                            val message = "HTTP ${it.code}: ${it.message}"
-                            val data = JsonElement(JsonPrimitive(text).toString())
-                            val error = RpcError(RpcError.CODE_CALL_FAILED, message, data)
-                            val failure = failure(error)
-
-                            LOG.err { "Batch request failed: $error" }
-
-                            for (i in batch.responses.indices) {
-                                batch.responses[i].complete(failure)
-                            }
-
-                            ret.complete(false)
-                            return
-                        }
-
                         val parsed = Kotlinx.DEFAULT.parseToJsonElement(text)
                         for (element in parsed.jsonArray) {
                             val obj = element.jsonObject
@@ -126,22 +86,43 @@ class HttpClient(
                             }
                             batch.responses[index].complete(result)
                         }
-
                         ret.complete(true)
-                    } catch (e: Exception) {
-                        LOG.err(e) { "Error processing batch response" }
-                        val rpcResponse = getResponseFromException(e)
-
-                        for (i in batch.responses.indices) {
-                            batch.responses[i].complete(rpcResponse)
-                        }
-
-                        ret.complete(false)
-                        return
+                        return@launch
+                    } catch (_: Exception) {
                     }
+
+                    val message = "HTTP ${response.status.value}: ${response.status.description}"
+                    val data = JsonElement(JsonPrimitive(text).toString())
+                    val error = RpcError(RpcError.CODE_CALL_FAILED, message, data)
+                    LOG.err { "Batch request failed: $error" }
+
+                    for (i in batch.responses.indices) {
+                        batch.responses[i].complete(failure(error))
+                    }
+                    ret.complete(false)
+                    return@launch
                 }
+
+                val parsed = Kotlinx.DEFAULT.parseToJsonElement(text)
+                for (element in parsed.jsonArray) {
+                    val obj = element.jsonObject
+                    var index = -1
+                    val result = obj.decodeNextResult { id ->
+                        index = requestIndexPerId[id] ?: throw Exception("Invalid response ID: $id")
+                        batch.requests[index].resultDecoder
+                    }
+                    batch.responses[index].complete(result)
+                }
+                ret.complete(true)
+            } catch (e: Exception) {
+                LOG.err(e) { "Error processing batch response" }
+                val rpcResponse = getResponseFromException(e)
+                for (i in batch.responses.indices) {
+                    batch.responses[i].complete(rpcResponse)
+                }
+                ret.complete(false)
             }
-        })
+        }
 
         return ret
     }
@@ -153,52 +134,42 @@ class HttpClient(
     ): CompletableFuture<Result<T, RpcError>> {
         val ret = CompletableFuture<Result<T, RpcError>>()
 
-        val body = createJsonRpcRequestBody(method, params)
-        val call = client.newCall(Request.Builder().url(httpUrl).headers(headers).post(body).build())
+        val json = buildJsonRpcRequest(method, requestId.getAndIncrement(), params)
+        LOG.trc { "Request: $json" }
 
-        call.enqueue(object : Callback {
-            override fun onFailure(call: Call, e: IOException) {
-                LOG.err(e) { "Error sending request for method=$method, params=${params.contentToString()}" }
+        scope.launch {
+            try {
+                val response = client.post(httpUrl) {
+                    contentType(ContentType.Application.Json)
+                    headers { requestHeaders.forEach { (k, v) -> append(k, v) } }
+                    setBody(json)
+                }
+                val text = response.bodyAsText()
+                LOG.trc { "Response: ${text.removeSuffix("\n")}" }
 
-                ret.complete(getResponseFromException(e))
-            }
-
-            override fun onResponse(call: Call, response: Response) {
-                response.use {
+                if (!response.status.value.let { it in 200..299 }) {
                     try {
-                        val text = it.body.string()
-                        LOG.trc { "Response: ${text.removeSuffix("\n")}" }
-
-                        if (!it.isSuccessful) {
-                            // first, try to decode a JSON response
-                            try {
-                                val obj = Kotlinx.DEFAULT.parseToJsonElement(text).jsonObject
-                                ret.complete(obj.decodeNextResult { resultDecoder })
-                                return
-                            } catch (_: Exception) {
-                            }
-
-                            // second, if decoding fails, return the response as a message
-                            val message = "HTTP ${it.code}: ${it.message}"
-                            val data = JsonElement(JsonPrimitive(text).toString())
-                            val error = RpcError(RpcError.CODE_CALL_FAILED, message, data)
-                            LOG.err { "Call failed for method=$method, params=${params.contentToString()}: $error" }
-
-                            ret.complete(failure(error))
-                            return
-                        }
-
                         val obj = Kotlinx.DEFAULT.parseToJsonElement(text).jsonObject
                         ret.complete(obj.decodeNextResult { resultDecoder })
-                    } catch (e: Exception) {
-                        LOG.err(e) { "Error processing response for method=$method, params=${params.contentToString()}" }
-
-                        ret.complete(getResponseFromException(e))
-                        return
+                        return@launch
+                    } catch (_: Exception) {
                     }
+
+                    val message = "HTTP ${response.status.value}: ${response.status.description}"
+                    val data = JsonElement(JsonPrimitive(text).toString())
+                    val error = RpcError(RpcError.CODE_CALL_FAILED, message, data)
+                    LOG.err { "Call failed for method=$method, params=${params.contentToString()}: $error" }
+                    ret.complete(failure(error))
+                    return@launch
                 }
+
+                val obj = Kotlinx.DEFAULT.parseToJsonElement(text).jsonObject
+                ret.complete(obj.decodeNextResult { resultDecoder })
+            } catch (e: Exception) {
+                LOG.err(e) { "Error processing response for method=$method, params=${params.contentToString()}" }
+                ret.complete(getResponseFromException(e))
             }
-        })
+        }
 
         return ret
     }
@@ -229,11 +200,11 @@ class HttpClient(
     }
 
     override fun close() {
-        client.dispatcher.executorService.shutdown()
-        client.connectionPool.evictAll()
+        scope.cancel()
+        client.close()
     }
 
-    private fun BatchRpcRequest.toRequestBody(): Pair<RequestBody, HashMap<Long, Int>> {
+    private fun BatchRpcRequest.toRequestBody(): Pair<String, HashMap<Long, Int>> {
         val requestIndexPerId = HashMap<Long, Int>(requests.size, 1.0F)
 
         val sb = StringBuilder(requests.size * BYTE_BUFFER_DEFAULT_SIZE)
@@ -249,18 +220,11 @@ class HttpClient(
 
         val json = sb.toString()
         LOG.trc { "Request: $json" }
-        return json.toByteArray().toRequestBody(JSON_MEDIA_TYPE) to requestIndexPerId
-    }
-
-    private fun createJsonRpcRequestBody(method: String, params: Array<*>): RequestBody {
-        val json = buildJsonRpcRequest(method, requestId.getAndIncrement(), params)
-        LOG.trc { "Request: $json" }
-        return json.toByteArray().toRequestBody(JSON_MEDIA_TYPE)
+        return json to requestIndexPerId
     }
 
     companion object {
         private const val BYTE_BUFFER_DEFAULT_SIZE = 128
-        private val JSON_MEDIA_TYPE = "application/json".toMediaType()
 
         private val ERROR_SUBSCRIPTION_UNSUPPORTED = failure(
             RpcError(
@@ -288,7 +252,7 @@ class HttpClient(
         private fun getResponseFromException(e: Exception): Result<Nothing, RpcError> {
             val msg = e.message
             return when {
-                msg != null && msg.contains("timeout") -> ERROR_CALL_TIMEOUT
+                msg != null && msg.contains("timeout", ignoreCase = true) -> ERROR_CALL_TIMEOUT
                 else -> failure(RpcError(RpcError.CODE_CALL_FAILED, msg ?: "call failed", null, e))
             }
         }

--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/JsonRpcClient.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/JsonRpcClient.kt
@@ -7,6 +7,8 @@ import io.ethers.core.Result
 import io.ethers.core.json.JsonElement
 import io.ethers.core.toJsonElement
 import io.ethers.providers.types.BatchRpcRequest
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.websocket.WebSockets
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
@@ -14,9 +16,8 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.serializer
-import okhttp3.OkHttpClient
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.TimeUnit
+import io.ktor.client.HttpClient as KtorHttpClient
 import kotlinx.serialization.json.JsonElement as KJsonElement
 
 interface JsonRpcClient : AutoCloseable {
@@ -267,7 +268,7 @@ class RpcClientConfig {
     /**
      * Client to use for making JSON-RPC requests. If not set, a default client will be used.
      * */
-    var client: OkHttpClient? = null
+    var client: KtorHttpClient? = null
         @JvmSynthetic set
         get() = field ?: DEFAULT_CLIENT
 
@@ -288,9 +289,21 @@ class RpcClientConfig {
         @JvmSynthetic set
 
     /**
+     * WebSocket connection timeout in milliseconds. Only used by [WsClient].
+     * */
+    var connectTimeoutMs: Long = 10_000L
+        @JvmSynthetic set
+
+    /**
+     * Request read timeout in milliseconds, used to expire in-flight requests. Only used by [WsClient].
+     * */
+    var readTimeoutMs: Long = 30_000L
+        @JvmSynthetic set
+
+    /**
      * Client to use for making JSON-RPC requests. If not set, a default client will be used.
      * */
-    fun client(client: OkHttpClient) = apply { this.client = client }
+    fun client(client: KtorHttpClient) = apply { this.client = client }
 
     /**
      * Headers to include with each RPC request. Can be used to set authorization headers, etc...
@@ -306,11 +319,17 @@ class RpcClientConfig {
      * */
     fun resubscribeOnReconnect(resubscribe: Boolean) = apply { this.resubscribeOnReconnect = resubscribe }
 
+    /** WebSocket connection timeout in milliseconds. Only used by [WsClient]. */
+    fun connectTimeoutMs(ms: Long) = apply { this.connectTimeoutMs = ms }
+
+    /** Request read timeout in milliseconds. Only used by [WsClient]. */
+    fun readTimeoutMs(ms: Long) = apply { this.readTimeoutMs = ms }
+
     companion object {
         private val DEFAULT_CLIENT by lazy {
-            OkHttpClient.Builder()
-                .pingInterval(10, TimeUnit.SECONDS)
-                .build()
+            KtorHttpClient(CIO) {
+                install(WebSockets) { pingIntervalMillis = 10_000L }
+            }
         }
 
         inline operator fun invoke(builder: RpcClientConfig.() -> Unit): RpcClientConfig {

--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/WsClient.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/WsClient.kt
@@ -18,7 +18,6 @@ import io.ethers.providers.types.BatchRpcRequest
 import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
 import io.ktor.client.plugins.websocket.webSocket
 import io.ktor.websocket.Frame
-import io.ktor.websocket.close
 import io.ktor.websocket.readText
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.locks.reentrantLock
@@ -34,7 +33,6 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.long
 import kotlinx.serialization.json.longOrNull
 import org.jctools.queues.MpscUnboundedXaddArrayQueue
 import org.jctools.queues.SpscUnboundedArrayQueue
@@ -73,6 +71,9 @@ class WsClient(
     private val LOG = getLogger()
 
     // these are modified by a single thread
+    private val pendingSendRequests = ArrayDeque<CompletableRequest<*>>()
+    private val pendingSendBatchRequests = ArrayDeque<CompletableBatchRequest>()
+    private val pendingSendSubscriptionRequests = ArrayDeque<CompletableSubscriptionRequest<*>>()
     private val inFlightRequests = HashMap<Long, CompletableRequest<*>>()
     private val inFlightBatchRequests = HashMap<Long, Pair<CompletableBatchRequest, HashMap<Long, Int>>>()
     private val inFlightSubscriptionRequests = HashMap<Long, CompletableSubscriptionRequest<*>>()
@@ -274,23 +275,35 @@ class WsClient(
 
                     // third, process all single and batch requests in the queue
                     while (requestQueue.poll().also { request = it } != null) {
+                        pendingSendRequests.addLast(request!!)
+                    }
+                    while (pendingSendRequests.isNotEmpty()) {
+                        val pending = pendingSendRequests.first()
                         val id = requestId++
-                        val req = buildJsonRpcRequest(request!!.method, id, request.params)
-
+                        val req = buildJsonRpcRequest(pending.method, id, pending.params)
                         LOG.trc { "Processing request: $req" }
-                        inFlightRequests[id] = request
-                        wsSend(req)
+                        if (wsSend(req)) {
+                            pendingSendRequests.removeFirst()
+                            inFlightRequests[id] = pending
+                        } else {
+                            requestReconnect()
+                            break
+                        }
                     }
 
                     while (batchRequestQueue.poll().also { batchRequest = it } != null) {
+                        pendingSendBatchRequests.addLast(batchRequest!!)
+                    }
+                    while (pendingSendBatchRequests.isNotEmpty()) {
+                        val pending = pendingSendBatchRequests.first()
                         var batchId = -1L
-                        val idToIndex = HashMap<Long, Int>(batchRequest!!.request.requests.size, 1.0F)
+                        val idToIndex = HashMap<Long, Int>(pending.request.requests.size, 1.0F)
 
                         val sb = StringBuilder()
                         sb.append('[')
-                        for (i in batchRequest.request.requests.indices) {
+                        for (i in pending.request.requests.indices) {
                             if (i > 0) sb.append(',')
-                            val reqItem = batchRequest.request.requests[i]
+                            val reqItem = pending.request.requests[i]
                             val id = requestId++
                             if (batchId == -1L) batchId = id
                             idToIndex[id] = i
@@ -299,21 +312,34 @@ class WsClient(
                         sb.append(']')
 
                         val req = sb.toString()
-
                         LOG.trc { "Processing batch request: $req" }
-                        inFlightBatchRequests[batchId] = Pair(batchRequest, idToIndex)
-                        wsSend(req)
-                        batchRequest.request.markAsSent()
+
+                        if (wsSend(req)) {
+                            pendingSendBatchRequests.removeFirst()
+                            inFlightBatchRequests[batchId] = Pair(pending, idToIndex)
+                            pending.request.markAsSent()
+                        } else {
+                            requestReconnect()
+                            break
+                        }
                     }
 
                     // fourth, process all subscription requests in the queue
                     while (subscriptionQueue.poll().also { subscriptionRequest = it } != null) {
+                        pendingSendSubscriptionRequests.addLast(subscriptionRequest!!)
+                    }
+                    while (pendingSendSubscriptionRequests.isNotEmpty()) {
+                        val pending = pendingSendSubscriptionRequests.first()
                         val id = requestId++
-                        val req = buildJsonRpcRequest("eth_subscribe", id, subscriptionRequest!!.params)
-
+                        val req = buildJsonRpcRequest("eth_subscribe", id, pending.params)
                         LOG.trc { "Processing subscription request: $req" }
-                        inFlightSubscriptionRequests[id] = subscriptionRequest
-                        wsSend(req)
+                        if (wsSend(req)) {
+                            pendingSendSubscriptionRequests.removeFirst()
+                            inFlightSubscriptionRequests[id] = pending
+                        } else {
+                            requestReconnect()
+                            break
+                        }
                     }
 
                     // fifth, process all unsubscribe requests in the queue
@@ -371,6 +397,13 @@ class WsClient(
         removeTimedOutRequests(inFlightRequests, timeout)
         removeTimedOutRequests(inFlightSubscriptionRequests, timeout)
         removeTimedOutBatchRequests(timeout)
+        removeTimedOutPending(pendingSendRequests, timeout)
+        removeTimedOutPending(pendingSendBatchRequests, timeout)
+        removeTimedOutPending(pendingSendSubscriptionRequests, timeout)
+    }
+
+    private fun <T : ExpiringRequest> removeTimedOutPending(pending: ArrayDeque<T>, timeout: Duration) {
+        pending.removeAll { it.expireIfTimedOut(timeout) }
     }
 
     private fun removeTimedOutBatchRequests(timeout: Duration) {

--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/WsClient.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/WsClient.kt
@@ -15,22 +15,27 @@ import io.ethers.logger.inf
 import io.ethers.logger.trc
 import io.ethers.logger.wrn
 import io.ethers.providers.types.BatchRpcRequest
+import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
+import io.ktor.client.plugins.websocket.webSocket
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import io.ktor.websocket.readText
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
 import kotlinx.serialization.json.longOrNull
-import okhttp3.Headers
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.Response
-import okhttp3.WebSocket
-import okhttp3.WebSocketListener
-import okio.ByteString
 import org.jctools.queues.MpscUnboundedXaddArrayQueue
 import org.jctools.queues.SpscUnboundedArrayQueue
 import java.util.concurrent.CompletableFuture
@@ -38,6 +43,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
+import io.ktor.client.HttpClient as KtorHttpClient
 import kotlinx.serialization.json.JsonElement as KJsonElement
 
 /**
@@ -48,9 +54,11 @@ import kotlinx.serialization.json.JsonElement as KJsonElement
  */
 class WsClient(
     url: String,
-    private val client: OkHttpClient,
+    private val client: KtorHttpClient,
     headers: Map<String, String> = emptyMap(),
     private val resubscribeOnReconnect: Boolean = true,
+    private val connectTimeoutMs: Long = 10_000L,
+    private val readTimeoutMs: Long = 30_000L,
 ) : JsonRpcClient {
     @JvmOverloads
     constructor(url: String, config: RpcClientConfig = RpcClientConfig()) : this(
@@ -58,6 +66,8 @@ class WsClient(
         config.client!!,
         config.requestHeaders,
         config.resubscribeOnReconnect,
+        config.connectTimeoutMs,
+        config.readTimeoutMs,
     )
 
     private val LOG = getLogger()
@@ -85,71 +95,79 @@ class WsClient(
     private val reconnect = atomic(false)
     private val stopping = atomic(false)
 
-    init {
-        val requestHeaders = Headers.Builder().apply { headers.forEach { (key, value) -> add(key, value) } }.build()
-        val wsRequest = Request.Builder().url(url).headers(requestHeaders).build()
-        val wsListener = object : WebSocketListener() {
-            override fun onOpen(webSocket: WebSocket, response: Response) {
+    private val wsScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val wsUrl = url.replace("http://", "ws://").replace("https://", "wss://")
+    private val wsHeaders = headers
+
+    @Volatile
+    private var currentSession: DefaultClientWebSocketSession? = null
+
+    @Volatile
+    private var wsJob: Job? = null
+
+    private fun openWebSocket(): Job = wsScope.launch {
+        try {
+            client.webSocket(wsUrl, request = {
+                wsHeaders.forEach { (k, v) -> headers.append(k, v) }
+            }) {
+                currentSession = this
                 LOG.inf { "WebSocket connection opened" }
-
                 eventLock.withLock { connectionOpenedCondition.signalAll() }
-            }
 
-            override fun onMessage(webSocket: WebSocket, text: String) {
-                messageQueue.add(text)
-
-                eventLock.withLock { newEventCondition.signalAll() }
-            }
-
-            override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
-                // will trigger "onFailure" callback
-                throw Exception("Binary messages are not supported")
-            }
-
-            override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
-                LOG.dbg { "WebSocket connection closing: $code $reason. Closing our side as well." }
-
-                webSocket.close(code, reason)
-            }
-
-            override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
-                LOG.dbg { "WebSocket connection closed: $code $reason" }
-
-                eventLock.withLock { connectionClosedCondition.signalAll() }
-
-                requestReconnect()
-            }
-
-            override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
-                eventLock.withLock { connectionClosedCondition.signalAll() }
-
-                if (stopping.value) {
-                    LOG.dbg(t) { "WebSocket failure ignored because we are stopping" }
-                    return
+                try {
+                    for (frame in incoming) {
+                        when (frame) {
+                            is Frame.Text -> {
+                                messageQueue.add(frame.readText())
+                                eventLock.withLock { newEventCondition.signalAll() }
+                            }
+                            is Frame.Close -> {
+                                LOG.dbg { "WebSocket connection closing (server close frame)" }
+                                break
+                            }
+                            else -> throw Exception("Binary messages are not supported")
+                        }
+                    }
+                } finally {
+                    currentSession = null
+                    eventLock.withLock { connectionClosedCondition.signalAll() }
+                    if (!stopping.value) requestReconnect()
                 }
-
-                LOG.err(t) { "WebSocket failure" }
-                requestReconnect()
             }
-
-            private fun requestReconnect() = eventLock.withLock {
-                reconnect.value = true
-
-                // wake up the processor thread, in case it's waiting for new events
-                newEventCondition.signalAll()
+        } catch (e: Throwable) {
+            when {
+                stopping.value -> LOG.dbg(e) { "WebSocket failure ignored because we are stopping" }
+                e is kotlinx.coroutines.CancellationException -> LOG.dbg { "WebSocket coroutine cancelled" }
+                else -> LOG.err(e) { "WebSocket failure" }
             }
+            currentSession = null
+            eventLock.withLock { connectionClosedCondition.signalAll() }
+            if (!stopping.value && e !is kotlinx.coroutines.CancellationException) requestReconnect()
         }
+    }
 
+    private fun wsSend(text: String): Boolean {
+        val session = currentSession ?: return false
+        return try {
+            runBlocking { session.send(Frame.Text(text)) }
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun requestReconnect() = eventLock.withLock {
+        reconnect.value = true
+        newEventCondition.signalAll()
+    }
+
+    init {
         val processorThread = AsyncExecutor.maybeVirtualThread {
             LOG.inf { "Starting WebSocket processor thread and connecting to websocket" }
 
-            var websocket = eventLock.withLock {
-                val ws = client.newWebSocket(wsRequest, wsListener)
-                connectionOpenedCondition.await(
-                    client.connectTimeoutMillis.toLong(),
-                    TimeUnit.MILLISECONDS,
-                )
-                ws
+            wsJob = openWebSocket()
+            eventLock.withLock {
+                connectionOpenedCondition.await(connectTimeoutMs, TimeUnit.MILLISECONDS)
             }
 
             var requestId = 1L
@@ -165,10 +183,7 @@ class WsClient(
                 try {
                     // first, process all messages in the queue
                     while (messageQueue.poll().also { msg = it } != null) {
-
-                        // messages are terminated by a new line. Remove it when logging to get nicer output
                         LOG.trc { "Processing message: ${msg?.removeSuffix("\n")}" }
-
                         try {
                             handleMessage(msg!!)
                         } catch (e: Exception) {
@@ -176,41 +191,30 @@ class WsClient(
                         }
                     }
 
-                    // second, check if we need to reconnect, initiating re-subscription for existing subs
+                    // second, check if we need to reconnect
                     if (reconnect.value) {
                         var reconnectSuccessful = false
 
                         while (!reconnectSuccessful && !stopping.value) {
                             LOG.dbg { "Trying to reconnect WebSocket" }
 
-                            // close the old websocket, just in case. Do this while holding a lock, so we don't start
-                            // awaiting on the condition after the ws listener already notified it, which would lead
-                            // to a deadlock
+                            // cancel the old job (triggers finally → signals connectionClosedCondition)
+                            wsJob?.cancel()
                             eventLock.withLock {
-                                if (websocket.close(1000, "Close")) {
+                                if (currentSession != null) {
                                     connectionClosedCondition.await()
                                 }
                             }
 
-                            // Clear the flag in each iteration since it might be set again while reconnecting.
-                            // Has to be done after closing in case connection is still open, since it will trigger
-                            // a new reconnection attempt
                             reconnect.value = false
 
-                            // and wait explicitly for the new connection to be opened, the delay acting as a back-off
+                            wsJob = openWebSocket()
                             reconnectSuccessful = eventLock.withLock {
-                                // sends the connection request asynchronously, so the lock won't be held very long
-                                websocket = client.newWebSocket(wsRequest, wsListener)
-
-                                connectionOpenedCondition.await(
-                                    client.connectTimeoutMillis.toLong(),
-                                    TimeUnit.MILLISECONDS,
-                                )
+                                connectionOpenedCondition.await(connectTimeoutMs, TimeUnit.MILLISECONDS)
                             }
 
                             if (!reconnectSuccessful) {
-                                handleTimeouts(client.readTimeoutMillis.toLong().milliseconds)
-
+                                handleTimeouts(readTimeoutMs.milliseconds)
                                 Thread.sleep(2000L)
                             }
                         }
@@ -225,7 +229,6 @@ class WsClient(
                             while (iter.hasNext()) {
                                 val value = iter.next().value
                                 LOG.dbg { "Re-queued in-flight request: $value" }
-
                                 requestQueue.add(value)
                                 iter.remove()
                             }
@@ -235,10 +238,9 @@ class WsClient(
                         if (inFlightBatchRequests.isNotEmpty()) {
                             val iter = inFlightBatchRequests.iterator()
                             while (iter.hasNext()) {
-                                val (batchRequest, _) = iter.next().value
-                                LOG.dbg { "Re-queued in-flight batch request: $batchRequest" }
-
-                                batchRequestQueue.add(batchRequest)
+                                val (batchReq, _) = iter.next().value
+                                LOG.dbg { "Re-queued in-flight batch request: $batchReq" }
+                                batchRequestQueue.add(batchReq)
                                 iter.remove()
                             }
                         }
@@ -249,7 +251,6 @@ class WsClient(
                             while (iter.hasNext()) {
                                 val value = iter.next().value
                                 LOG.dbg { "Re-queued in-flight subscription request: $value" }
-
                                 subscriptionQueue.add(value)
                                 iter.remove()
                             }
@@ -257,18 +258,15 @@ class WsClient(
 
                         // handle existing streams: either resubscribe or close them
                         if (resubscribeOnReconnect) {
-                            // send resubscribe requests for all existing streams
                             for ((id, sub) in requestIdToSubscription) {
                                 LOG.dbg { "Resubscribing stream with ID: $id" }
-                                websocket.send(buildJsonRpcRequest("eth_subscribe", id, sub.params))
+                                wsSend(buildJsonRpcRequest("eth_subscribe", id, sub.params))
                             }
                         } else {
-                            // close all streams so consumers can handle resubscription explicitly
                             for ((id, sub) in requestIdToSubscription) {
                                 LOG.dbg { "Closing stream on reconnect: $id" }
                                 sub.stream.close()
                             }
-
                             requestIdToSubscription.clear()
                             serverIdToSubscription.clear()
                         }
@@ -281,7 +279,7 @@ class WsClient(
 
                         LOG.trc { "Processing request: $req" }
                         inFlightRequests[id] = request
-                        websocket.send(req)
+                        wsSend(req)
                     }
 
                     while (batchRequestQueue.poll().also { batchRequest = it } != null) {
@@ -304,7 +302,7 @@ class WsClient(
 
                         LOG.trc { "Processing batch request: $req" }
                         inFlightBatchRequests[batchId] = Pair(batchRequest, idToIndex)
-                        websocket.send(req)
+                        wsSend(req)
                         batchRequest.request.markAsSent()
                     }
 
@@ -315,7 +313,7 @@ class WsClient(
 
                         LOG.trc { "Processing subscription request: $req" }
                         inFlightSubscriptionRequests[id] = subscriptionRequest
-                        websocket.send(req)
+                        wsSend(req)
                     }
 
                     // fifth, process all unsubscribe requests in the queue
@@ -329,19 +327,16 @@ class WsClient(
                         val req = buildJsonRpcRequest("eth_unsubscribe", id, arrayOf(sub.serverId))
 
                         LOG.trc { "Processing unsubscribe request: $req" }
-                        websocket.send(req)
+                        wsSend(req)
                     }
 
                     // check and handle timed-out requests every 1000ms
                     if (lastTimeoutCheck.elapsedNow() > 1000.milliseconds) {
-                        handleTimeouts(client.readTimeoutMillis.toLong().milliseconds)
+                        handleTimeouts(readTimeoutMs.milliseconds)
                         lastTimeoutCheck = TimeSource.Monotonic.markNow()
                     }
 
                     eventLock.withLock {
-                        // do a quick check if any new events arrived while processing requests, while holding the lock
-                        // to prevent race conditions, so we don't wait unnecessarily. We wait for max 1 second, so we
-                        // still process timeouts in a timely manner, even if there are no new events.
                         if (messageQueue.isEmpty &&
                             requestQueue.isEmpty &&
                             batchRequestQueue.isEmpty &&
@@ -353,13 +348,12 @@ class WsClient(
                     }
                 } catch (e: Exception) {
                     LOG.err(e) { "Exception when processing events, reconnecting WebSocket" }
-
                     reconnect.value = true
                 }
             }
 
-            // close the websocket, expire all remaining requests, and unsubscribe from all subscriptions
-            websocket.close(1000, "Close")
+            // shutdown: cancel WS, expire all remaining requests, close subscriptions
+            wsJob?.cancel()
             handleTimeouts(Duration.ZERO)
             for ((_, subscription) in requestIdToSubscription) {
                 subscription.stream.close()
@@ -380,7 +374,6 @@ class WsClient(
     }
 
     private fun removeTimedOutBatchRequests(timeout: Duration) {
-        // skip expiration if timeout is not set or requests are empty
         if (timeout.inWholeMilliseconds < 0 || inFlightBatchRequests.isEmpty()) {
             return
         }
@@ -397,7 +390,6 @@ class WsClient(
     }
 
     private fun <T : ExpiringRequest> removeTimedOutRequests(requests: MutableMap<Long, T>, timeout: Duration) {
-        // skip expiration if timeout is not set or requests are empty
         if (timeout.inWholeMilliseconds < 0 || requests.isEmpty()) {
             return
         }
@@ -431,11 +423,8 @@ class WsClient(
         // DO NOT CHANGE ORDER OF THESE OPERATIONS
         when {
             method != null && paramsEl != null -> handleNotification(paramsEl.jsonObject)
-
             id != -1L && error != null -> handleResponse(id, null, error)
-
             id != -1L && resultEl != null -> handleResponse(id, resultEl, null)
-
             else -> {
                 val invalid = RpcError(
                     RpcError.CODE_INVALID_RESPONSE,
@@ -491,13 +480,11 @@ class WsClient(
     }
 
     private fun getBatchFromRequestId(requestId: Long): Pair<CompletableBatchRequest, HashMap<Long, Int>>? {
-        // Handle if the batch returned responses in the same order as they were sent
         val directMatch = inFlightBatchRequests.remove(requestId)
         if (directMatch != null) {
             return directMatch
         }
 
-        // Find a batch by looking through all in-flight batches for one containing this ID
         for ((batchId, data) in inFlightBatchRequests) {
             if (data.second.containsKey(requestId)) {
                 return inFlightBatchRequests.remove(batchId)
@@ -541,7 +528,6 @@ class WsClient(
         }
 
         LOG.trc { "Handled response for request $id: $response" }
-
         request.future.complete(response)
     }
 
@@ -559,11 +545,8 @@ class WsClient(
                 params = request.params,
                 resultDecoder = request.resultDecoder,
                 stream = QueueChannel.spscUnbounded {
-                    // requestId is constant even across re-subscriptions. Just queue for processor thread.
                     unsubscribeQueue.add(id)
-                    eventLock.withLock {
-                        newEventCondition.signalAll()
-                    }
+                    eventLock.withLock { newEventCondition.signalAll() }
                 },
             )
 
@@ -583,14 +566,10 @@ class WsClient(
         error: RpcError?,
     ) {
         if (error != null) {
-            // will cause re-subscription to be attempted again
             throw Exception("Error re-subscribing to stream: ${subscription.serverId}, error: $error")
         } else {
             val newServerId = resultElement!!.jsonPrimitive.content
-            // remove old serverId
             serverIdToSubscription.remove(subscription.serverId)
-
-            // update serverId with new value
             subscription.serverId = newServerId
             serverIdToSubscription[subscription.serverId] = subscription
         }
@@ -612,12 +591,10 @@ class WsClient(
         LOG.inf { "Requesting to close WebSocket" }
 
         stopping.value = true
-
-        // wake up the event loop thread so it can exit
         eventLock.withLock { newEventCondition.signalAll() }
 
-        client.dispatcher.executorService.shutdown()
-        client.connectionPool.evictAll()
+        wsScope.cancel()
+        client.close()
     }
 
     override fun requestBatch(batch: BatchRpcRequest): CompletableFuture<Boolean> {
@@ -673,7 +650,6 @@ class WsClient(
                 expireRequest()
                 return true
             }
-
             return false
         }
 
@@ -697,10 +673,8 @@ class WsClient(
     ) : ExpiringRequest() {
         override fun expireRequest() {
             for (i in request.responses.indices) {
-                val response = request.responses[i]
-                response.complete(HttpClient.ERROR_CALL_TIMEOUT)
+                request.responses[i].complete(HttpClient.ERROR_CALL_TIMEOUT)
             }
-
             future.complete(false)
         }
     }

--- a/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/HttpClientTest.kt
+++ b/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/HttpClientTest.kt
@@ -11,13 +11,14 @@ import io.kotest.core.spec.style.funSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
+import io.ktor.client.engine.cio.CIO
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
-import okhttp3.OkHttpClient
-import okhttp3.mockwebserver.MockResponse
 import org.intellij.lang.annotations.Language
+import java.math.BigInteger
+import io.ktor.client.HttpClient as KtorHttpClient
 import kotlinx.serialization.json.JsonElement as KJsonElement
 
 /**
@@ -31,7 +32,7 @@ class HttpClientTest : FunSpec({
     include(
         JsonRpcTestFactory.commonTests(
             RpcClientVariant.HTTP,
-            { url -> HttpClient(url, OkHttpClient()) },
+            { url -> HttpClient(url, KtorHttpClient(CIO)) },
         ),
     )
 
@@ -47,7 +48,7 @@ private fun httpSpecificTests() = funSpec {
 
         beforeEach {
             server = mockServerHttp()
-            client = HttpClient(server.url, OkHttpClient())
+            client = HttpClient(server.url, KtorHttpClient(CIO))
         }
 
         afterEach {
@@ -55,7 +56,7 @@ private fun httpSpecificTests() = funSpec {
         }
 
         test("HTTP error with JSON response") {
-            server.enqueue(createMockResponse(RPC_ERROR_RESPONSE, 500))
+            server.enqueue(500, RPC_ERROR_RESPONSE)
 
             val result = client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder).get()
 
@@ -66,7 +67,7 @@ private fun httpSpecificTests() = funSpec {
         }
 
         test("HTTP error with non-JSON response") {
-            server.enqueue(MockResponse().setResponseCode(500).setBody("Internal Server Error"))
+            server.enqueue(500, "Internal Server Error")
 
             val result = client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder).get()
 
@@ -77,20 +78,20 @@ private fun httpSpecificTests() = funSpec {
         }
 
         test("empty response body") {
-            server.enqueue(MockResponse().setResponseCode(200).setBody(""))
+            server.enqueue(200, "")
 
             val result = client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder).get()
 
             result.isFailure() shouldBe true
             val error = result.unwrapError()
-            error.code shouldBe RpcError.CODE_CALL_FAILED // Jackson parsing error for empty content
+            error.code shouldBe RpcError.CODE_CALL_FAILED
         }
 
         test("custom headers are sent") {
-            server.enqueue(createMockResponse(SUCCESSFUL_RESPONSE))
+            server.enqueueJson(SUCCESSFUL_RESPONSE)
 
             val headersMap = mapOf("Authorization" to "Bearer token123", "Custom-Header" to "value")
-            val clientWithHeaders = HttpClient(server.url, OkHttpClient(), headersMap)
+            val clientWithHeaders = HttpClient(server.url, KtorHttpClient(CIO), headersMap)
 
             clientWithHeaders.request("eth_blockNumber", emptyArray<Any>(), stringDecoder).get()
 
@@ -100,12 +101,12 @@ private fun httpSpecificTests() = funSpec {
         }
 
         test("content-Type header is set correctly") {
-            server.enqueue(createMockResponse(SUCCESSFUL_RESPONSE))
+            server.enqueueJson(SUCCESSFUL_RESPONSE)
 
             client.request("eth_blockNumber", emptyArray<Any>(), stringDecoder).get()
 
             val request = server.takeRequest()
-            request.getHeader("Content-Type") shouldBe "application/json"
+            request.getHeader("Content-Type") shouldContain "application/json"
         }
 
         test("complex Map / BigInteger / ByteArray params are emitted as proper JSON") {
@@ -187,8 +188,8 @@ private fun httpSpecificTests() = funSpec {
         }
 
         test("unique request IDs are generated") {
-            server.enqueue(createMockResponse(SUCCESSFUL_RESPONSE))
-            server.enqueue(createMockResponse(SUCCESSFUL_RESPONSE))
+            server.enqueueJson(SUCCESSFUL_RESPONSE)
+            server.enqueueJson(SUCCESSFUL_RESPONSE)
 
             client.request("method1", emptyArray<Any>(), stringDecoder).get()
             client.request("method2", emptyArray<Any>(), stringDecoder).get()
@@ -196,8 +197,8 @@ private fun httpSpecificTests() = funSpec {
             val request1 = server.takeRequest()
             val request2 = server.takeRequest()
 
-            val body1 = Kotlinx.DEFAULT.parseToJsonElement(request1.body.readUtf8()).jsonObject
-            val body2 = Kotlinx.DEFAULT.parseToJsonElement(request2.body.readUtf8()).jsonObject
+            val body1 = Kotlinx.DEFAULT.parseToJsonElement(request1.bodyText).jsonObject
+            val body2 = Kotlinx.DEFAULT.parseToJsonElement(request2.bodyText).jsonObject
 
             body1["id"]!!.jsonPrimitive.long shouldNotBe body2["id"]!!.jsonPrimitive.long
         }
@@ -205,7 +206,7 @@ private fun httpSpecificTests() = funSpec {
 
     context("Subscription tests") {
         test("subscription is not supported") {
-            val httpClient = HttpClient("http://localhost:8545", OkHttpClient())
+            val httpClient = HttpClient("http://localhost:8545", KtorHttpClient(CIO))
             val result = httpClient.subscribe(arrayOf("newHeads"), stringDecoder).get()
 
             result.isFailure() shouldBe true
@@ -214,10 +215,6 @@ private fun httpSpecificTests() = funSpec {
             error.message shouldContain "not supported by HTTP client"
         }
     }
-}
-
-private fun createMockResponse(body: String, code: Int = 200): MockResponse {
-    return MockResponse().setResponseCode(code).setBody(body)
 }
 
 @Language("JSON")

--- a/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/HttpClientTest.kt
+++ b/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/HttpClientTest.kt
@@ -17,7 +17,6 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
 import org.intellij.lang.annotations.Language
-import java.math.BigInteger
 import io.ktor.client.HttpClient as KtorHttpClient
 import kotlinx.serialization.json.JsonElement as KJsonElement
 

--- a/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/HttpClientTest.kt
+++ b/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/HttpClientTest.kt
@@ -110,7 +110,7 @@ private fun httpSpecificTests() = funSpec {
         }
 
         test("complex Map / BigInteger / ByteArray params are emitted as proper JSON") {
-            server.enqueue(createMockResponse(SUCCESSFUL_RESPONSE))
+            server.enqueueJson(SUCCESSFUL_RESPONSE)
 
             val callMap = mapOf(
                 "from" to Address("0x1111111111111111111111111111111111111111"),
@@ -122,7 +122,7 @@ private fun httpSpecificTests() = funSpec {
             client.request("eth_call", arrayOf(callMap, "latest"), stringDecoder).get()
 
             val body = Kotlinx.DEFAULT.parseToJsonElement(
-                server.takeRequest().body.readUtf8(),
+                server.takeRequest().bodyText,
             ).jsonObject
 
             body["method"]!!.jsonPrimitive.content shouldBe "eth_call"
@@ -150,11 +150,7 @@ private fun httpSpecificTests() = funSpec {
         }
 
         test("request(Class<T>) with ByteArray decodes a 0x-prefixed hex string") {
-            server.enqueue(
-                createMockResponse(
-                    """{"jsonrpc":"2.0","id":1,"result":"0xdeadbeef"}""",
-                ),
-            )
+            server.enqueueJson("""{"jsonrpc":"2.0","id":1,"result":"0xdeadbeef"}""")
 
             val result = client.request("eth_getCode", emptyArray<Any>(), ByteArray::class.java).get()
 
@@ -163,23 +159,19 @@ private fun httpSpecificTests() = funSpec {
         }
 
         test("request(Class<T>) with ByteArray handles empty payloads (\"0x\" / \"\")") {
-            server.enqueue(createMockResponse("""{"jsonrpc":"2.0","id":1,"result":"0x"}"""))
+            server.enqueueJson("""{"jsonrpc":"2.0","id":1,"result":"0x"}""")
             val emptyHex = client.request("eth_getCode", emptyArray<Any>(), ByteArray::class.java).get()
             emptyHex.isSuccess() shouldBe true
             emptyHex.unwrap() shouldBe ByteArray(0)
 
-            server.enqueue(createMockResponse("""{"jsonrpc":"2.0","id":2,"result":""}"""))
+            server.enqueueJson("""{"jsonrpc":"2.0","id":2,"result":""}""")
             val emptyString = client.request("eth_getCode", emptyArray<Any>(), ByteArray::class.java).get()
             emptyString.isSuccess() shouldBe true
             emptyString.unwrap() shouldBe ByteArray(0)
         }
 
         test("request(Class<T>) with @Serializable type still uses its KSerializer") {
-            server.enqueue(
-                createMockResponse(
-                    """{"jsonrpc":"2.0","id":1,"result":"0x1111111111111111111111111111111111111111"}""",
-                ),
-            )
+            server.enqueueJson("""{"jsonrpc":"2.0","id":1,"result":"0x1111111111111111111111111111111111111111"}""")
 
             val result = client.request("eth_coinbase", emptyArray<Any>(), Address::class.java).get()
 

--- a/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/MockServer.kt
+++ b/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/MockServer.kt
@@ -5,15 +5,24 @@ import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import okhttp3.mockwebserver.RecordedRequest
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
+
+/** Captured HTTP request from a mock server. */
+data class RecordedRequest(
+    val headersMap: Map<String, String>,
+    val bodyBytes: ByteArray,
+) {
+    fun getHeader(name: String): String? = headersMap.entries.firstOrNull { it.key.equals(name, ignoreCase = true) }?.value
+
+    val bodyText: String get() = bodyBytes.decodeToString()
+}
 
 interface MockServer {
     val url: String
 
     fun enqueueJson(json: String)
-    fun enqueue(response: MockResponse)
+    fun enqueue(statusCode: Int, body: String)
     fun takeRequest(): RecordedRequest
 }
 
@@ -30,7 +39,7 @@ interface MockWSServer : MockServer {
 }
 
 /**
- * Create [MockServer] that supports enqueuing mock requests.
+ * Create [MockServer] that supports enqueuing mock HTTP requests.
  * */
 fun mockServerHttp(): MockServer {
     val server = MockWebServer()
@@ -40,23 +49,23 @@ fun mockServerHttp(): MockServer {
         override val url: String
             get() = server.url("/").toString()
 
-        override fun enqueueJson(json: String) {
-            server.enqueue(MockResponse().setResponseCode(200).setBody(json))
-        }
+        override fun enqueueJson(json: String) = enqueue(200, json)
 
-        override fun enqueue(response: MockResponse) {
-            server.enqueue(response)
+        override fun enqueue(statusCode: Int, body: String) {
+            server.enqueue(MockResponse().setResponseCode(statusCode).setBody(body))
         }
 
         override fun takeRequest(): RecordedRequest {
-            return server.takeRequest()
+            val req = server.takeRequest()
+            val headers = req.headers.toMultimap().mapValues { (_, v) -> v.firstOrNull().orEmpty() }
+            return RecordedRequest(headers, req.body.readByteArray())
         }
     }
 }
 
 /**
- * Create a [MockWSServer] that automatically upgrade the connection to Websockets and supports sending WS text
- * messages.
+ * Create a [MockWSServer] that automatically upgrades the connection to WebSocket and supports
+ * sending / receiving WS text messages.
  * */
 fun mockServerWebsocket(): MockWSServer {
     val server = MockWebServer()
@@ -80,23 +89,24 @@ fun mockServerWebsocket(): MockWSServer {
 
         override fun onMessage(webSocket: WebSocket, text: String) {
             receivedMessages.add(text)
-            webSocket.send(msgQueue.removeFirst())
+            val response = msgQueue.removeFirstOrNull()
+            if (response != null) webSocket.send(response)
         }
 
-        override fun takeReceivedText(timeoutMs: Long): String? {
-            return receivedMessages.poll(timeoutMs, TimeUnit.MILLISECONDS)
-        }
+        override fun takeReceivedText(timeoutMs: Long): String? = receivedMessages.poll(timeoutMs, TimeUnit.MILLISECONDS)
 
         override fun enqueueJson(json: String) {
             msgQueue.add(json)
         }
 
-        override fun enqueue(response: MockResponse) {
-            server.enqueue(response)
+        override fun enqueue(statusCode: Int, body: String) {
+            server.enqueue(MockResponse().setResponseCode(statusCode).setBody(body))
         }
 
         override fun takeRequest(): RecordedRequest {
-            return server.takeRequest()
+            val req = server.takeRequest()
+            val headers = req.headers.toMultimap().mapValues { (_, v) -> v.firstOrNull().orEmpty() }
+            return RecordedRequest(headers, req.body.readByteArray())
         }
 
         override fun sendJson(json: String) {

--- a/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/WsClientTest.kt
+++ b/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/WsClientTest.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
 import org.intellij.lang.annotations.Language
-import java.math.BigInteger
+import kotlin.collections.mapOf
 import kotlin.time.Duration.Companion.seconds
 import io.ktor.client.HttpClient as KtorHttpClient
 import kotlinx.serialization.json.JsonElement as KJsonElement

--- a/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/WsClientTest.kt
+++ b/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/WsClientTest.kt
@@ -8,15 +8,17 @@ import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.websocket.WebSockets
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
-import okhttp3.OkHttpClient
 import org.intellij.lang.annotations.Language
-import java.util.concurrent.TimeUnit
+import java.math.BigInteger
 import kotlin.time.Duration.Companion.seconds
+import io.ktor.client.HttpClient as KtorHttpClient
 import kotlinx.serialization.json.JsonElement as KJsonElement
 
 /**
@@ -31,11 +33,7 @@ class WsClientTest : FunSpec({
     val commonJsonRpcTests = JsonRpcTestFactory.commonTests(
         RpcClientVariant.WS,
         { url ->
-            val okhttp = OkHttpClient.Builder()
-                .readTimeout(50, TimeUnit.MILLISECONDS)
-                .build()
-
-            WsClient(url, okhttp)
+            WsClient(url, KtorHttpClient(CIO) { install(WebSockets) }, readTimeoutMs = 50L)
         },
     )
     include(commonJsonRpcTests)
@@ -47,7 +45,7 @@ class WsClientTest : FunSpec({
 
         beforeEach {
             mockServer = mockServerWebsocket()
-            wsClient = WsClient(mockServer.url, OkHttpClient())
+            wsClient = WsClient(mockServer.url, KtorHttpClient(CIO) { install(WebSockets) })
         }
 
         afterEach {
@@ -116,7 +114,7 @@ class WsClientTest : FunSpec({
 
         beforeEach {
             mockServer = mockServerWebsocket()
-            wsClient = WsClient(mockServer.url, OkHttpClient())
+            wsClient = WsClient(mockServer.url, KtorHttpClient(CIO) { install(WebSockets) })
         }
 
         afterEach {
@@ -231,7 +229,7 @@ class WsClientTest : FunSpec({
             // Create client with resubscribeOnReconnect = false
             wsClient = WsClient(
                 mockServer.url,
-                OkHttpClient(),
+                KtorHttpClient(CIO) { install(WebSockets) },
                 emptyMap(),
                 resubscribeOnReconnect = false,
             )
@@ -271,7 +269,7 @@ class WsClientTest : FunSpec({
             mockServer.enqueueJson("""{"jsonrpc":"2.0","id":1,"result":"$subscriptionId"}""")
 
             // Create client with default settings (resubscribeOnReconnect = true)
-            wsClient = WsClient(mockServer.url, OkHttpClient())
+            wsClient = WsClient(mockServer.url, KtorHttpClient(CIO) { install(WebSockets) })
 
             // Subscribe to new block headers
             val params = arrayOf("newHeads")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,8 +7,8 @@ eclipse-collections = "13.0.0"
 ksp = "2.3.9"
 kotest = "6.0.7"
 jmh = "1.37"
-okhttp3 = "5.3.2"
 klogging = "8.0.4"
+ktor = "3.2.2"
 ktlint-tool = "1.8.0"
 web3j = "4.10.3"
 ethers = "1.6.0"
@@ -57,9 +57,11 @@ jackson-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin"
 eclipse-collections-core = { module = "org.eclipse.collections:eclipse-collections", version.ref = "eclipse-collections" }
 eclipse-collections-api = { module = "org.eclipse.collections:eclipse-collections-api", version.ref = "eclipse-collections" }
 
-okhttp3-core = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
-okhttp3-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp3" }
-okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-websockets = { module = "io.ktor:ktor-client-websockets", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version = "5.3.2" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version = "2.3.0" }
 
 kotlincrypto-hash-sha3 = { module = "org.kotlincrypto.hash:sha3", version.ref = "kotlincrypto" }
@@ -107,7 +109,7 @@ web3j-crypto = { module = "corg.web3j:crypto", version.ref = "web3j" }
 [bundles]
 log4j2 = ["log4j2-core", "log4j2-api", "log4j2-slf4j"]
 jackson = ["jackson-databind"]
-okhttp3 = ["okhttp3-core", "okhttp3-logging"]
+ktor-client = ["ktor-client-core", "ktor-client-cio", "ktor-client-websockets"]
 ethers = ["ethers-abi", "ethers-core", "ethers-crypto", "ethers-ens", "ethers-providers", "ethers-rlp", "ethers-signers"]
 
 ##################### TEST #####################


### PR DESCRIPTION
## Summary

Replaces OkHttp 5.x with Ktor 3.2.2 (CIO engine) as the HTTP and WebSocket
client across `ethers-providers` and `ethers-ens`, completing the migration
away from OkHttp started in previous commits.

- **`ethers-providers`** — `HttpClient` and `WsClient` now use `KtorHttpClient`
  with a coroutine-based dispatch scope; `JsonRpcClient` updated accordingly
- **`ethers-ens`** — `EnsMiddleware` CCIP-read and NFT metadata requests ported
  to Ktor; `buildCcipRequest` helper inlined and removed
- **deps** — `okhttp3` bundle replaced by `ktor-client` bundle (core + cio +
  websockets); `okhttp3-mockwebserver` kept as a test-only dependency

## Test plan

- [ ] `./gradlew ktlintFormat` — no formatting issues
- [ ] `./gradlew :ethers-providers:kotest` — all HTTP and WebSocket client tests pass
- [ ] `./gradlew :ethers-ens:kotest` — ENS middleware tests pass
- [ ] `./gradlew check` — full project checks green