### PR TITLE
feat(ethers-abi)!: add safe event and error decoding APIs

### DIFF
--- a/ethers-abi/src/commonMain/kotlin/io/ethers/abi/AbiEvent.kt
+++ b/ethers-abi/src/commonMain/kotlin/io/ethers/abi/AbiEvent.kt
@@ -1,6 +1,10 @@
 package io.ethers.abi
 
 import io.ethers.abi.AbiEvent.Companion.NON_VALUE_INDEXED_TYPE
+import io.ethers.core.Result
+import io.ethers.core.ThrowableError
+import io.ethers.core.failure
+import io.ethers.core.success
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Hash
 import io.ethers.core.types.Log
@@ -40,11 +44,13 @@ interface EventFactory<T : ContractEvent> {
     }
 
     /**
-     * Decode the [log] into this event type, returning null if the log does not match this event.
+     * Decode the [log] into this event type, returning null if the log does not match this event or decoding fails.
      *
-     * @return the decoded event, or null if the log does not match this event.
+     * If you need to know why decoding failed, use [tryDecode].
+     *
+     * @return the decoded event, or null if the log does not match this event or cannot be decoded.
      * */
-    fun decode(log: Log): T? {
+    fun decodeOrNull(log: Log): T? {
         val topics: List<Any>
         val data: List<Any>
         val logTopicSize: Int
@@ -54,16 +60,24 @@ interface EventFactory<T : ContractEvent> {
             if (abi.indexed.size != logTopicSize) return null
             if (abi.data.isEmpty() != log.data.isEmpty) return null
 
-            topics = if (logTopicSize == 0) emptyList() else abi.decodeTopics(log.topics)
-            data = if (abi.data.isEmpty()) emptyList() else abi.decodeData(log.data)
+            try {
+                topics = if (logTopicSize == 0) emptyList() else abi.decodeTopics(log.topics)
+                data = if (abi.data.isEmpty()) emptyList() else abi.decodeData(log.data)
+            } catch (_: Exception) {
+                return null
+            }
         } else {
             logTopicSize = log.topics.size - 1
             if (abi.indexed.size != logTopicSize) return null
             if (abi.data.isEmpty() != log.data.isEmpty) return null
             if (abi.topicId != log.topics[0]) return null
 
-            topics = if (logTopicSize == 0) emptyList() else abi.decodeTopics(log.topics)
-            data = if (abi.data.isEmpty()) emptyList() else abi.decodeData(log.data)
+            try {
+                topics = if (logTopicSize == 0) emptyList() else abi.decodeTopics(log.topics)
+                data = if (abi.data.isEmpty()) emptyList() else abi.decodeData(log.data)
+            } catch (_: Exception) {
+                return null
+            }
         }
 
         var topicIndex = 0
@@ -77,10 +91,84 @@ interface EventFactory<T : ContractEvent> {
             }
         }
 
-        return decode(log, merged)
+        return try {
+            decode(log, merged)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Try to decode the [log] into this event type.
+     *
+     * @return the decoded event, or an [EventDecodingError] if the log does not match or cannot be decoded.
+     * */
+    fun tryDecode(log: Log): Result<T, EventDecodingError> {
+        val topics: List<Any>
+        val data: List<Any>
+        val logTopicSize: Int
+
+        if (abi.isAnonymous) {
+            logTopicSize = log.topics.size
+            if (abi.indexed.size != logTopicSize) return failure(EventDecodingError.NoMatchingEvent(log, listOf(abi)))
+            if (abi.data.isEmpty() != log.data.isEmpty) return failure(EventDecodingError.NoMatchingEvent(log, listOf(abi)))
+
+            try {
+                topics = if (logTopicSize == 0) emptyList() else abi.decodeTopics(log.topics)
+                data = if (abi.data.isEmpty()) emptyList() else abi.decodeData(log.data)
+            } catch (e: Exception) {
+                return failure(EventDecodingError.MalformedEvent(log, abi, e))
+            }
+        } else {
+            logTopicSize = log.topics.size - 1
+            if (abi.indexed.size != logTopicSize) return failure(EventDecodingError.NoMatchingEvent(log, listOf(abi)))
+            if (abi.data.isEmpty() != log.data.isEmpty) return failure(EventDecodingError.NoMatchingEvent(log, listOf(abi)))
+            if (abi.topicId != log.topics[0]) return failure(EventDecodingError.NoMatchingEvent(log, listOf(abi)))
+
+            try {
+                topics = if (logTopicSize == 0) emptyList() else abi.decodeTopics(log.topics)
+                data = if (abi.data.isEmpty()) emptyList() else abi.decodeData(log.data)
+            } catch (e: Exception) {
+                return failure(EventDecodingError.MalformedEvent(log, abi, e))
+            }
+        }
+
+        var topicIndex = 0
+        var dataIndex = 0
+        val merged = ArrayList<Any>(logTopicSize + data.size)
+        for (i in 0 until (logTopicSize + data.size)) {
+            if (abi.tokens[i].indexed) {
+                merged.add(topics[topicIndex++])
+            } else {
+                merged.add(data[dataIndex++])
+            }
+        }
+
+        return try {
+            success(decode(log, merged))
+        } catch (e: Exception) {
+            failure(EventDecodingError.MalformedEvent(log, abi, e))
+        }
     }
 
     fun decode(log: Log, data: List<Any>): T
+}
+
+sealed class EventDecodingError(
+    open val log: Log,
+    override val message: String,
+    override val cause: Exception? = null,
+) : ThrowableError {
+    data class NoMatchingEvent(
+        override val log: Log,
+        val expectedEvents: List<AbiEvent>,
+    ) : EventDecodingError(log, "Log does not match any expected event")
+
+    data class MalformedEvent(
+        override val log: Log,
+        val expectedEvent: AbiEvent,
+        override val cause: Exception,
+    ) : EventDecodingError(log, "Unable to decode event log", cause)
 }
 
 data class AbiEvent(
@@ -145,42 +233,86 @@ interface ContractEvent {
 }
 
 /**
- * Decode the [Log] into any event of `this` types, returning null if the log does not match the event.
+ * Decode the [Log] into any event of `this` types, returning null if the log does not match the event or decoding fails.
  * */
-fun <T : ContractEvent> List<EventFactory<out T>>.decode(log: Log): T? {
+fun <T : ContractEvent> List<EventFactory<out T>>.decodeOrNull(log: Log): T? {
     for (i in indices) {
-        val event = log.toEventOrNull(this[i])
-        if (event != null) {
-            return event
-        }
+        return this[i].decodeOrNull(log) ?: continue
     }
     return null
 }
 
 /**
- * Decode the [Log] into any event of `this` types, returning null if the log does not match the event.
+ * Try to decode the [Log] into any event of `this` types.
  * */
-fun <T : ContractEvent> Array<out EventFactory<out T>>.decode(log: Log): T? {
-    for (i in this) {
-        val event = log.toEventOrNull(i)
-        if (event != null) {
-            return event
+fun <T : ContractEvent> List<EventFactory<out T>>.tryDecode(log: Log): Result<T, EventDecodingError> {
+    for (i in indices) {
+        when (val event = this[i].tryDecode(log)) {
+            is Result.Success -> return success(event.value)
+            is Result.Failure -> {
+                if (event.error !is EventDecodingError.NoMatchingEvent) {
+                    return failure(event.error)
+                }
+            }
         }
+    }
+    return failure(EventDecodingError.NoMatchingEvent(log, map { it.abi }))
+}
+
+/**
+ * Decode the [Log] into any event of `this` types, returning null if the log does not match the event or decoding fails.
+ * */
+fun <T : ContractEvent> Array<out EventFactory<out T>>.decodeOrNull(log: Log): T? {
+    for (i in this) {
+        return i.decodeOrNull(log) ?: continue
     }
     return null
 }
 
 /**
- * Decode the [Log] into any event of `this` types, returning null if the log does not match the event.
+ * Try to decode the [Log] into any event of `this` types.
  * */
-fun <T : ContractEvent> Iterable<EventFactory<out T>>.decode(log: Log): T? {
+fun <T : ContractEvent> Array<out EventFactory<out T>>.tryDecode(log: Log): Result<T, EventDecodingError> {
     for (i in this) {
-        val event = log.toEventOrNull(i)
-        if (event != null) {
-            return event
+        when (val event = i.tryDecode(log)) {
+            is Result.Success -> return success(event.value)
+            is Result.Failure -> {
+                if (event.error !is EventDecodingError.NoMatchingEvent) {
+                    return failure(event.error)
+                }
+            }
         }
     }
+    return failure(EventDecodingError.NoMatchingEvent(log, map { it.abi }))
+}
+
+/**
+ * Decode the [Log] into any event of `this` types, returning null if the log does not match the event or decoding fails.
+ * */
+fun <T : ContractEvent> Iterable<EventFactory<out T>>.decodeOrNull(log: Log): T? {
+    for (i in this) {
+        return i.decodeOrNull(log) ?: continue
+    }
     return null
+}
+
+/**
+ * Try to decode the [Log] into any event of `this` types.
+ * */
+fun <T : ContractEvent> Iterable<EventFactory<out T>>.tryDecode(log: Log): Result<T, EventDecodingError> {
+    val expectedEvents = ArrayList<AbiEvent>()
+    for (i in this) {
+        expectedEvents.add(i.abi)
+        when (val event = i.tryDecode(log)) {
+            is Result.Success -> return success(event.value)
+            is Result.Failure -> {
+                if (event.error !is EventDecodingError.NoMatchingEvent) {
+                    return failure(event.error)
+                }
+            }
+        }
+    }
+    return failure(EventDecodingError.NoMatchingEvent(log, expectedEvents))
 }
 
 /**
@@ -228,44 +360,54 @@ fun Log.isEvent(vararg events: EventFactory<*>): Boolean {
  * Decode the [Log] into an event of the [event] type, returning null if the log does not match the event.
  * */
 fun <T : ContractEvent> Log.toEventOrNull(event: EventFactory<T>): T? {
-    return event.decode(this)
+    return event.decodeOrNull(this)
+}
+
+/**
+ * Try to decode this [Log] into an event of the [event] type.
+ * */
+fun <T : ContractEvent> Log.tryToEvent(event: EventFactory<T>): Result<T, EventDecodingError> {
+    return event.tryDecode(this)
 }
 
 /**
  * Decode the [Log] into any event of the [events] types, returning null if the log does not match any event.
  * */
 fun <T : ContractEvent> Log.toEventOrNull(events: List<EventFactory<out T>>): T? {
-    for (i in events.indices) {
-        val event = this.toEventOrNull(events[i])
-        if (event != null) {
-            return event
-        }
-    }
-    return null
+    return events.decodeOrNull(this)
+}
+
+/**
+ * Try to decode this [Log] into any event of the [events] types.
+ * */
+fun <T : ContractEvent> Log.tryToEvent(events: List<EventFactory<out T>>): Result<T, EventDecodingError> {
+    return events.tryDecode(this)
 }
 
 /**
  * Decode the [Log] into any event of the [events] types, returning null if the log does not match any event.
  * */
 fun <T : ContractEvent> Log.toEventOrNull(events: Iterable<EventFactory<out T>>): T? {
-    for (e in events) {
-        val event = this.toEventOrNull(e)
-        if (event != null) {
-            return event
-        }
-    }
-    return null
+    return events.decodeOrNull(this)
+}
+
+/**
+ * Try to decode this [Log] into any event of the [events] types.
+ * */
+fun <T : ContractEvent> Log.tryToEvent(events: Iterable<EventFactory<out T>>): Result<T, EventDecodingError> {
+    return events.tryDecode(this)
 }
 
 /**
  * Decode the [Log] into any event of the [events] types, returning null if the log does not match any event.
  * */
 fun <T : ContractEvent> Log.toEventOrNull(vararg events: EventFactory<out T>): T? {
-    for (e in events) {
-        val event = this.toEventOrNull(e)
-        if (event != null) {
-            return event
-        }
-    }
-    return null
+    return events.decodeOrNull(this)
+}
+
+/**
+ * Try to decode this [Log] into any event of the [events] types.
+ * */
+fun <T : ContractEvent> Log.tryToEvent(vararg events: EventFactory<out T>): Result<T, EventDecodingError> {
+    return events.tryDecode(this)
 }

--- a/ethers-abi/src/commonMain/kotlin/io/ethers/abi/EventFilters.kt
+++ b/ethers-abi/src/commonMain/kotlin/io/ethers/abi/EventFilters.kt
@@ -154,7 +154,7 @@ abstract class EventFilterBase<T : ContractEvent, F : EventFilterBase<T, F>>(
      * subscriptions. If the provider supports subscriptions, [subscribe] should be used instead.
      * */
     fun watch(): RpcRequest<FilterPoller<T>, RpcError> {
-        return provider.watchLogs(filter).map { it.mapNotNull(factory::decode) }
+        return provider.watchLogs(filter).map { it.mapNotNull(factory::decodeOrNull) }
     }
 
     /**
@@ -162,7 +162,7 @@ abstract class EventFilterBase<T : ContractEvent, F : EventFilterBase<T, F>>(
      * subscriptions.
      * */
     fun subscribe(): RpcSubscribe<T, RpcError> {
-        return provider.subscribeLogs(filter).map { it.mapNotNull(factory::decode) }
+        return provider.subscribeLogs(filter).map { it.mapNotNull(factory::decodeOrNull) }
     }
 
     /**
@@ -185,7 +185,7 @@ abstract class EventFilterBase<T : ContractEvent, F : EventFilterBase<T, F>>(
     private fun decodeMatchingLogs(logs: List<Log>): List<T> {
         val ret = ArrayList<T>(logs.size)
         for (i in logs.indices) {
-            val event = factory.decode(logs[i]) ?: continue
+            val event = factory.decodeOrNull(logs[i]) ?: continue
             ret.add(event)
         }
         return ret

--- a/ethers-abi/src/commonMain/kotlin/io/ethers/abi/error/ContractError.kt
+++ b/ethers-abi/src/commonMain/kotlin/io/ethers/abi/error/ContractError.kt
@@ -5,6 +5,8 @@ import io.ethers.abi.AbiFunction
 import io.ethers.abi.AbiType
 import io.ethers.core.Result
 import io.ethers.core.ThrowableError
+import io.ethers.core.failure
+import io.ethers.core.success
 import io.ethers.core.types.Bytes
 import io.ethers.providers.RpcError
 import io.github.artificialpb.bignum.BigInteger
@@ -24,21 +26,69 @@ sealed class ContractError : ThrowableError {
          * */
         @JvmStatic
         fun getOrNull(data: Bytes): ContractError? {
-            val panic = PanicError.getOrNull(data)
-            if (panic != null) {
-                return panic
-            }
-            val revert = RevertError.getOrNull(data)
-            if (revert != null) {
-                return revert
-            }
-            val customError = CustomErrorRegistry.getOrNull(data)
-            if (customError != null) {
-                return customError
-            }
+            PanicError.getOrNull(data)?.let { return it }
+            RevertError.getOrNull(data)?.let { return it }
+            CustomErrorRegistry.getOrNull(data)?.let { return it }
             return null
         }
+
+        /**
+         * Try to get either [PanicError], [RevertError], or [CustomContractError] from provided [data].
+         *
+         * @return the decoded error, or a [ContractErrorDecodingError] if [data] cannot be decoded.
+         * */
+        @JvmStatic
+        fun tryGet(data: Bytes): Result<ContractError, ContractErrorDecodingError> {
+            // collected from each candidate, so the returned NoMatchingError names everything that was tried
+            val expectedErrors = ArrayList<AbiFunction>()
+
+            when (val panic = PanicError.tryGet(data)) {
+                is Result.Success -> return success(panic.value)
+                is Result.Failure -> {
+                    val error = panic.error
+                    if (error !is ContractErrorDecodingError.NoMatchingError) return failure(error)
+                    expectedErrors.addAll(error.expectedErrors)
+                }
+            }
+
+            when (val revert = RevertError.tryGet(data)) {
+                is Result.Success -> return success(revert.value)
+                is Result.Failure -> {
+                    val error = revert.error
+                    if (error !is ContractErrorDecodingError.NoMatchingError) return failure(error)
+                    expectedErrors.addAll(error.expectedErrors)
+                }
+            }
+
+            when (val customError = CustomErrorRegistry.tryGet(data)) {
+                is Result.Success -> return success(customError.value)
+                is Result.Failure -> {
+                    val error = customError.error
+                    if (error !is ContractErrorDecodingError.NoMatchingError) return failure(error)
+                    expectedErrors.addAll(error.expectedErrors)
+                }
+            }
+
+            return failure(ContractErrorDecodingError.NoMatchingError(data, expectedErrors))
+        }
     }
+}
+
+sealed class ContractErrorDecodingError(
+    open val data: Bytes,
+    override val message: String,
+    override val cause: Exception? = null,
+) : ThrowableError {
+    data class NoMatchingError(
+        override val data: Bytes,
+        val expectedErrors: List<AbiFunction>,
+    ) : ContractErrorDecodingError(data, "Data does not match any expected contract error")
+
+    data class MalformedError(
+        override val data: Bytes,
+        val expectedError: AbiFunction?,
+        override val cause: Exception,
+    ) : ContractErrorDecodingError(data, "Unable to decode contract error", cause)
 }
 
 /**
@@ -117,7 +167,11 @@ data class PanicError(val kind: Kind) : ContractError() {
             if (data.size < 4) return null
             if (!data.startsWith(FUNCTION.selector)) return null
 
-            val decoded = AbiCodec.decodeWithPrefix(FUNCTION.selector.size, FUNCTION.inputs, data.asByteArray())
+            val decoded = try {
+                AbiCodec.decodeWithPrefix(FUNCTION.selector.size, FUNCTION.inputs, data.asByteArray())
+            } catch (_: Exception) {
+                return null
+            }
             val errorCode = decoded[0] as BigInteger
 
             for (i in Kind.entries.indices) {
@@ -128,6 +182,33 @@ data class PanicError(val kind: Kind) : ContractError() {
             }
 
             return null
+        }
+
+        /**
+         * Try to decode [PanicError] from [data].
+         *
+         * @return the decoded [PanicError], or a [ContractErrorDecodingError] if [data] cannot be decoded into [PanicError].
+         * */
+        @JvmStatic
+        fun tryGet(data: Bytes): Result<PanicError, ContractErrorDecodingError> {
+            if (data.size < 4) return failure(ContractErrorDecodingError.NoMatchingError(data, listOf(FUNCTION)))
+            if (!data.startsWith(FUNCTION.selector)) return failure(ContractErrorDecodingError.NoMatchingError(data, listOf(FUNCTION)))
+
+            val decoded = try {
+                AbiCodec.decodeWithPrefix(FUNCTION.selector.size, FUNCTION.inputs, data.asByteArray())
+            } catch (e: Exception) {
+                return failure(ContractErrorDecodingError.MalformedError(data, FUNCTION, e))
+            }
+            val errorCode = decoded[0] as BigInteger
+
+            for (i in Kind.entries.indices) {
+                val kind = Kind.entries[i]
+                if (kind.code == errorCode) {
+                    return success(PanicError(kind))
+                }
+            }
+
+            return failure(ContractErrorDecodingError.NoMatchingError(data, listOf(FUNCTION)))
         }
     }
 }
@@ -149,8 +230,30 @@ data class RevertError(val reason: String) : ContractError() {
         fun getOrNull(data: Bytes): RevertError? {
             if (data.size < 4) return null
             if (!data.startsWith(FUNCTION.selector)) return null
-            val decoded = AbiCodec.decodeWithPrefix(FUNCTION.selector.size, FUNCTION.inputs, data.asByteArray())
+
+            val decoded = try {
+                AbiCodec.decodeWithPrefix(FUNCTION.selector.size, FUNCTION.inputs, data.asByteArray())
+            } catch (_: Exception) {
+                return null
+            }
             return RevertError(decoded[0] as String)
+        }
+
+        /**
+         * Try to decode [RevertError] from [data].
+         *
+         * @return the decoded [RevertError], or a [ContractErrorDecodingError] if [data] cannot be decoded into [RevertError].
+         * */
+        @JvmStatic
+        fun tryGet(data: Bytes): Result<RevertError, ContractErrorDecodingError> {
+            if (data.size < 4) return failure(ContractErrorDecodingError.NoMatchingError(data, listOf(FUNCTION)))
+            if (!data.startsWith(FUNCTION.selector)) return failure(ContractErrorDecodingError.NoMatchingError(data, listOf(FUNCTION)))
+            val decoded = try {
+                AbiCodec.decodeWithPrefix(FUNCTION.selector.size, FUNCTION.inputs, data.asByteArray())
+            } catch (e: Exception) {
+                return failure(ContractErrorDecodingError.MalformedError(data, FUNCTION, e))
+            }
+            return success(RevertError(decoded[0] as String))
         }
     }
 }
@@ -182,14 +285,56 @@ abstract class CustomContractError : ContractError()
 interface CustomErrorFactory<T : CustomContractError> {
     val abi: AbiFunction
 
-    fun decode(data: Bytes): T? {
+    /**
+     * Decode [data] into this error type, returning null if the data does not match this error or decoding fails.
+     *
+     * If you need to know why decoding failed, use [tryDecode].
+     * */
+    fun decodeOrNull(data: Bytes): T? {
         if (data.size < 4) return null
         if (!data.startsWith(abi.selector)) return null
 
-        return decode(abi.decodeCall(data))
+        return try {
+            decode(abi.decodeCall(data))
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    fun tryDecode(data: Bytes): Result<T, ContractErrorDecodingError> {
+        if (data.size < 4) return failure(ContractErrorDecodingError.NoMatchingError(data, listOf(abi)))
+        if (!data.startsWith(abi.selector)) return failure(ContractErrorDecodingError.NoMatchingError(data, listOf(abi)))
+
+        return try {
+            success(decode(abi.decodeCall(data)))
+        } catch (e: Exception) {
+            failure(ContractErrorDecodingError.MalformedError(data, abi, e))
+        }
     }
 
     fun decode(data: List<Any>): T
+}
+
+fun <T : CustomContractError> List<CustomErrorFactory<out T>>.decodeOrNull(error: Bytes): T? {
+    for (i in indices) {
+        return this[i].decodeOrNull(error) ?: continue
+    }
+    return null
+}
+
+fun <T : CustomContractError> List<CustomErrorFactory<out T>>.tryDecode(error: Bytes): Result<T, ContractErrorDecodingError> {
+    for (i in indices) {
+        when (val decoded = this[i].tryDecode(error)) {
+            is Result.Success -> return success(decoded.value)
+            is Result.Failure -> {
+                if (decoded.error !is ContractErrorDecodingError.NoMatchingError) {
+                    return failure(decoded.error)
+                }
+            }
+        }
+    }
+
+    return failure(ContractErrorDecodingError.NoMatchingError(error, map { it.abi }))
 }
 
 /**

--- a/ethers-abi/src/commonMain/kotlin/io/ethers/abi/error/CustomErrorRegistry.kt
+++ b/ethers-abi/src/commonMain/kotlin/io/ethers/abi/error/CustomErrorRegistry.kt
@@ -1,7 +1,11 @@
 package io.ethers.abi.error
 
+import io.ethers.abi.AbiFunction
 import io.ethers.abi.error.CustomErrorRegistry.appendResolver
 import io.ethers.abi.error.CustomErrorRegistry.prependResolver
+import io.ethers.core.Result
+import io.ethers.core.failure
+import io.ethers.core.success
 import io.ethers.core.types.Bytes
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
@@ -54,13 +58,41 @@ object CustomErrorRegistry {
         if (error.size < 4) return null
 
         for (i in resolvers.indices) {
-            val customError = resolvers[i].resolve(error)
-            if (customError != null) {
-                return customError
+            val customError = try {
+                resolvers[i].resolve(error)
+            } catch (_: Exception) {
+                return null
             }
+            if (customError != null) return customError
         }
 
         return null
+    }
+
+    /**
+     * Try to return decoded [CustomContractError] from the first [CustomErrorResolver] that can decode it.
+     *
+     * @return the decoded [CustomContractError], or a [ContractErrorDecodingError] if decoding fails.
+     * */
+    @JvmStatic
+    fun tryGet(error: Bytes): Result<CustomContractError, ContractErrorDecodingError> {
+        if (error.size < 4) return failure(ContractErrorDecodingError.NoMatchingError(error, emptyList()))
+
+        // collected from each resolver, so the returned NoMatchingError names everything that was tried
+        val expectedErrors = ArrayList<AbiFunction>()
+
+        for (i in resolvers.indices) {
+            when (val customError = resolvers[i].tryResolve(error)) {
+                is Result.Success -> return success(customError.value)
+                is Result.Failure -> {
+                    val err = customError.error
+                    if (err !is ContractErrorDecodingError.NoMatchingError) return failure(err)
+                    expectedErrors.addAll(err.expectedErrors)
+                }
+            }
+        }
+
+        return failure(ContractErrorDecodingError.NoMatchingError(error, expectedErrors))
     }
 }
 
@@ -69,6 +101,15 @@ object CustomErrorRegistry {
  * */
 interface CustomErrorResolver {
     fun resolve(error: Bytes): CustomContractError?
+
+    fun tryResolve(error: Bytes): Result<CustomContractError, ContractErrorDecodingError> {
+        return try {
+            resolve(error)?.let(::success)
+                ?: failure(ContractErrorDecodingError.NoMatchingError(error, emptyList()))
+        } catch (e: Exception) {
+            failure(ContractErrorDecodingError.MalformedError(error, null, e))
+        }
+    }
 }
 
 /**
@@ -95,12 +136,32 @@ object CustomErrorFactoryResolver : CustomErrorResolver {
     }
 
     override fun resolve(error: Bytes): CustomContractError? {
+        if (error.size < 4) return null
+
         // the values are only appended to the end of the list, so we can safely iterate by index. Worst case,
         // we miss newly added errors in the current iteration.
         for (i in factories.indices) {
-            return factories[i].decode(error) ?: continue
+            // keep going on a decoding failure: distinct errors can share a 4-byte selector
+            return factories[i].decodeOrNull(error) ?: continue
         }
 
         return null
+    }
+
+    override fun tryResolve(error: Bytes): Result<CustomContractError, ContractErrorDecodingError> {
+        // the values are only appended to the end of the list, so we can safely iterate by index. Worst case,
+        // we miss newly added errors in the current iteration.
+        for (i in factories.indices) {
+            when (val decoded = factories[i].tryDecode(error)) {
+                is Result.Success -> return success(decoded.value)
+                is Result.Failure -> {
+                    if (decoded.error !is ContractErrorDecodingError.NoMatchingError) {
+                        return failure(decoded.error)
+                    }
+                }
+            }
+        }
+
+        return failure(ContractErrorDecodingError.NoMatchingError(error, factories.map { it.abi }))
     }
 }

--- a/ethers-abi/src/commonTest/kotlin/io/ethers/abi/AbiEventTest.kt
+++ b/ethers-abi/src/commonTest/kotlin/io/ethers/abi/AbiEventTest.kt
@@ -1,5 +1,6 @@
 package io.ethers.abi
 
+import io.ethers.core.isFailure
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Hash
@@ -8,6 +9,7 @@ import io.ethers.providers.middleware.Middleware
 import io.github.artificialpb.bignum.BigInteger
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.property.Exhaustive
 import io.kotest.property.checkAll
 import io.kotest.property.exhaustive.of
@@ -61,7 +63,7 @@ class AbiEventTest : FunSpec({
                 removed = false,
             )
 
-            val event = LogNote.decode(log)
+            val event = LogNote.decodeOrNull(log)
             event shouldBe LogNote(
                 sig = Bytes("0x9f678cca"),
                 usr = Address("0x83f20f44975d03b1b09e64809b757c47f942beea"),
@@ -89,7 +91,7 @@ class AbiEventTest : FunSpec({
                 removed = false,
             )
 
-            LogNote.decode(log) shouldBe null
+            LogNote.decodeOrNull(log) shouldBe null
         }
 
         test("anonymous event with no data returns null") {
@@ -111,7 +113,7 @@ class AbiEventTest : FunSpec({
                 removed = false,
             )
 
-            LogNote.decode(log) shouldBe null
+            LogNote.decodeOrNull(log) shouldBe null
         }
 
         test("non-anonymous event") {
@@ -132,7 +134,7 @@ class AbiEventTest : FunSpec({
                 removed = false,
             )
 
-            val event = Transfer.decode(log)
+            val event = Transfer.decodeOrNull(log)
             event shouldBe Transfer(
                 from = Address("0x855f02967ee16e9f18d388b07b4c75211e73e8c2"),
                 to = Address("0xed12310d5a37326e6506209c4838146950166760"),
@@ -160,7 +162,7 @@ class AbiEventTest : FunSpec({
                 removed = false,
             )
 
-            Transfer.decode(log) shouldBe null
+            Transfer.decodeOrNull(log) shouldBe null
         }
 
         test("non-anonymous event with no data returns null") {
@@ -181,7 +183,7 @@ class AbiEventTest : FunSpec({
                 removed = false,
             )
 
-            Transfer.decode(log) shouldBe null
+            Transfer.decodeOrNull(log) shouldBe null
         }
 
         test("non-anonymous event with different topicId returns null") {
@@ -202,7 +204,33 @@ class AbiEventTest : FunSpec({
                 removed = false,
             )
 
-            Transfer.decode(log) shouldBe null
+            Transfer.decodeOrNull(log) shouldBe null
+        }
+
+        test("non-anonymous event with malformed matching data returns null") {
+            val log = Log(
+                address = Address("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+                topics = listOf(
+                    Transfer.abi.topicId,
+                    Hash("0x000000000000000000000000855f02967ee16e9f18d388b07b4c75211e73e8c2"),
+                    Hash("0x000000000000000000000000ed12310d5a37326e6506209c4838146950166760"),
+                ),
+                data = Bytes("0x01"),
+                blockHash = Hash.ZERO,
+                blockNumber = 1,
+                blockTimestamp = 1,
+                transactionHash = Hash.ZERO,
+                transactionIndex = 0,
+                logIndex = 0,
+                removed = false,
+            )
+
+            Transfer.decodeOrNull(log) shouldBe null
+            Transfer.decodeOrNull(log) shouldBe null
+
+            val decoded = Transfer.tryDecode(log)
+            decoded.isFailure() shouldBe true
+            decoded.unwrapError().shouldBeInstanceOf<EventDecodingError.MalformedEvent>()
         }
     }
 
@@ -475,6 +503,15 @@ class AbiEventTest : FunSpec({
         test("toEventOrNull with vararg returns null when none match") {
             invalidLog.toEventOrNull(Transfer, LogNote) shouldBe null
         }
+
+        test("tryToEvent with vararg returns failure when matching event data is malformed") {
+            val malformedLog = validTransferLog.copy(data = Bytes("0x01"))
+
+            val decoded = malformedLog.tryToEvent(Transfer, LogNote)
+            decoded.isFailure() shouldBe true
+            decoded.unwrapError().shouldBeInstanceOf<EventDecodingError.MalformedEvent>()
+            malformedLog.toEventOrNull(Transfer, LogNote) shouldBe null
+        }
     }
 
     context("List/Array EventFactory decode extension") {
@@ -508,37 +545,37 @@ class AbiEventTest : FunSpec({
             removed = false,
         )
 
-        test("List<EventFactory>.decode matches") {
+        test("List<EventFactory>.decodeOrNull matches") {
             val factories = listOf(Transfer, LogNote)
-            val event = factories.decode(validTransferLog)
+            val event = factories.decodeOrNull(validTransferLog)
             (event is Transfer) shouldBe true
         }
 
-        test("List<EventFactory>.decode returns null when none match") {
+        test("List<EventFactory>.decodeOrNull returns null when none match") {
             val factories = listOf(Transfer, LogNote)
-            factories.decode(invalidLog) shouldBe null
+            factories.decodeOrNull(invalidLog) shouldBe null
         }
 
-        test("Array<EventFactory>.decode matches") {
+        test("Array<EventFactory>.decodeOrNull matches") {
             val factories = arrayOf<EventFactory<out ContractEvent>>(Transfer, LogNote)
-            val event = factories.decode(validTransferLog)
+            val event = factories.decodeOrNull(validTransferLog)
             (event is Transfer) shouldBe true
         }
 
-        test("Array<EventFactory>.decode returns null when none match") {
+        test("Array<EventFactory>.decodeOrNull returns null when none match") {
             val factories = arrayOf<EventFactory<out ContractEvent>>(Transfer, LogNote)
-            factories.decode(invalidLog) shouldBe null
+            factories.decodeOrNull(invalidLog) shouldBe null
         }
 
-        test("Iterable<EventFactory>.decode matches") {
+        test("Iterable<EventFactory>.decodeOrNull matches") {
             val factories: Iterable<EventFactory<out ContractEvent>> = setOf(Transfer, LogNote)
-            val event = factories.decode(validTransferLog)
+            val event = factories.decodeOrNull(validTransferLog)
             (event is Transfer) shouldBe true
         }
 
-        test("Iterable<EventFactory>.decode returns null when none match") {
+        test("Iterable<EventFactory>.decodeOrNull returns null when none match") {
             val factories: Iterable<EventFactory<out ContractEvent>> = setOf(Transfer, LogNote)
-            factories.decode(invalidLog) shouldBe null
+            factories.decodeOrNull(invalidLog) shouldBe null
         }
     }
 }) {

--- a/ethers-abi/src/commonTest/kotlin/io/ethers/abi/error/CustomErrorTest.kt
+++ b/ethers-abi/src/commonTest/kotlin/io/ethers/abi/error/CustomErrorTest.kt
@@ -4,12 +4,15 @@ import io.ethers.abi.AbiFunction
 import io.ethers.abi.AbiType
 import io.ethers.abi.ContractStruct
 import io.ethers.abi.StructFactory
+import io.ethers.core.isFailure
 import io.ethers.core.types.Bytes
 import io.github.artificialpb.bignum.BigInteger
 import io.github.artificialpb.bignum.bigIntegerOf
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
@@ -57,20 +60,86 @@ class CustomErrorTest : FunSpec({
             CustomErrorRegistry.getOrNull(it) shouldBe null
         }
     }
+
+    test("decoding malformed matching custom error returns null or failure") {
+        val data = ErrorWithStruct.abi.selector
+
+        ErrorWithStruct.decodeOrNull(data) shouldBe null
+        ErrorWithStruct.decodeOrNull(data) shouldBe null
+
+        val decoded = ErrorWithStruct.tryDecode(data)
+        decoded.isFailure() shouldBe true
+        decoded.unwrapError().shouldBeInstanceOf<ContractErrorDecodingError.MalformedError>()
+    }
+
+    test("decoding malformed matching revert error returns null or failure") {
+        val data = RevertError.FUNCTION.selector
+
+        RevertError.getOrNull(data) shouldBe null
+        ContractError.getOrNull(data) shouldBe null
+
+        val decoded = ContractError.tryGet(data)
+        decoded.isFailure() shouldBe true
+        decoded.unwrapError().shouldBeInstanceOf<ContractErrorDecodingError.MalformedError>()
+    }
+
+    test("NoMatchingError names every candidate that was tried") {
+        // unknown selector, so nothing matches and all candidates get reported
+        val data = Bytes("0x31920d0e0000000000000000000000000000000000000000000000000000000000000001")
+
+        val error = ContractError.tryGet(data)
+            .unwrapError()
+            .shouldBeInstanceOf<ContractErrorDecodingError.NoMatchingError>()
+
+        error.expectedErrors shouldContain PanicError.FUNCTION
+        error.expectedErrors shouldContain RevertError.FUNCTION
+    }
+
+    test("resolve keeps searching when a selector-colliding factory fails to decode") {
+        // both factories have the same signature, so they share a selector. The first one always fails to decode,
+        // and must not prevent the second one from resolving the error.
+        CustomErrorFactoryResolver.addFactories(listOf(FailingCollidingErrorFactory, CollidingError))
+
+        val encoded = CollidingError.abi.encodeCall(listOf(bigIntegerOf(7)))
+
+        CustomErrorFactoryResolver.resolve(encoded) shouldBe CollidingError(bigIntegerOf(7))
+
+        // the Result-based path reports the first malformed match instead, since it can tell the two apart
+        CustomErrorFactoryResolver.tryResolve(encoded)
+            .unwrapError()
+            .shouldBeInstanceOf<ContractErrorDecodingError.MalformedError>()
+    }
 }) {
+    private data class CollidingError(val flag: BigInteger) : CustomContractError() {
+        companion object : CustomErrorFactory<CollidingError> {
+            @JvmStatic
+            override val abi: AbiFunction = AbiFunction("CollidingError", listOf(AbiType.UInt(256)), emptyList())
+
+            @JvmStatic
+            override fun decode(data: List<Any>): CollidingError = CollidingError(data[0] as BigInteger)
+        }
+    }
+
+    /** Same signature as [CollidingError], so it matches the same selector, but never decodes successfully. */
+    private object FailingCollidingErrorFactory : CustomErrorFactory<CollidingError> {
+        override val abi: AbiFunction = AbiFunction("CollidingError", listOf(AbiType.UInt(256)), emptyList())
+
+        override fun decode(data: List<Any>): CollidingError = throw IllegalStateException("cannot decode")
+    }
+
     private class MockCustomErrorResolver : CustomErrorResolver {
         override fun resolve(error: Bytes): CustomContractError? {
-            val err1 = ErrorWithStruct.decode(error)
+            val err1 = ErrorWithStruct.decodeOrNull(error)
             if (err1 != null) {
                 return err1
             }
 
-            val err2 = NoArgsError.decode(error)
+            val err2 = NoArgsError.decodeOrNull(error)
             if (err2 != null) {
                 return err2
             }
 
-            val err3 = InvalidFlashswapFlags.decode(error)
+            val err3 = InvalidFlashswapFlags.decodeOrNull(error)
             if (err3 != null) {
                 return err3
             }

--- a/ethers-abigen-plugin/src/main/kotlin/io/ethers/abigen/plugin/task/EthersAbigenTask.kt
+++ b/ethers-abigen-plugin/src/main/kotlin/io/ethers/abigen/plugin/task/EthersAbigenTask.kt
@@ -74,7 +74,7 @@ abstract class EthersAbigenTask @Inject constructor(private val executor: Worker
      * causes the new version of the plugin to invalidate previous output automatically.
      * */
     @get:Input
-    internal val outputVersion: Property<String> = objectFactory.property(String::class.java).convention("8")
+    internal val outputVersion: Property<String> = objectFactory.property(String::class.java).convention("9")
 
     /**
      * Project path for generating loader prefix. This property is used instead of direct project.path access

--- a/ethers-abigen/src/jvmSharedMain/kotlin/io/ethers/abigen/AbiContractBuilder.kt
+++ b/ethers-abigen/src/jvmSharedMain/kotlin/io/ethers/abigen/AbiContractBuilder.kt
@@ -21,6 +21,7 @@ import io.ethers.abi.AbiType
 import io.ethers.abi.AnonymousEventFilter
 import io.ethers.abi.AnonymousEventFilterBase
 import io.ethers.abi.ContractEvent
+import io.ethers.abi.EventDecodingError
 import io.ethers.abi.EventFactory
 import io.ethers.abi.EventFilter
 import io.ethers.abi.EventFilterBase
@@ -31,9 +32,11 @@ import io.ethers.abi.call.PayableFunctionCall
 import io.ethers.abi.call.ReadFunctionCall
 import io.ethers.abi.call.ReceiveFunctionCall
 import io.ethers.abi.error.ContractError
+import io.ethers.abi.error.ContractErrorDecodingError
 import io.ethers.abi.error.CustomContractError
 import io.ethers.abi.error.CustomErrorFactory
 import io.ethers.abi.error.CustomErrorFactoryResolver
+import io.ethers.core.Result
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Hash
@@ -209,16 +212,48 @@ class AbiContractBuilder(
             )
 
             companion.addFunction(
-                FunSpec.builder("decodeError")
+                FunSpec.builder("decodeErrorOrNull")
                     .addAnnotation(JvmStatic::class)
                     .addParameter("error", Bytes::class)
                     .returns(errorSuperclass.copy(nullable = true))
                     .addCode(
                         CodeBlock.builder().apply {
                             beginControlFlow("for (err in ERRORS)")
-                            addStatement("return err.decode(error) ?: continue")
+                            addStatement("return err.decodeOrNull(error) ?: continue")
                             endControlFlow()
                             addStatement("return null")
+                        }.build(),
+                    )
+                    .build(),
+            )
+
+            companion.addFunction(
+                FunSpec.builder("tryDecodeError")
+                    .addAnnotation(JvmStatic::class)
+                    .addParameter("error", Bytes::class)
+                    .returns(
+                        Result::class.asClassName().parameterizedBy(
+                            errorSuperclass,
+                            ContractErrorDecodingError::class.asClassName(),
+                        ),
+                    )
+                    .addCode(
+                        CodeBlock.builder().apply {
+                            beginControlFlow("for (err in ERRORS)")
+                            beginControlFlow("when (val decoded = err.tryDecode(error))")
+                            addStatement("is %T.Success -> return %T.success(decoded.value)", Result::class, Result::class)
+                            beginControlFlow("is %T.Failure ->", Result::class)
+                            beginControlFlow("if (decoded.error !is %T.NoMatchingError)", ContractErrorDecodingError::class)
+                            addStatement("return %T.failure(decoded.error)", Result::class)
+                            endControlFlow()
+                            endControlFlow()
+                            endControlFlow()
+                            endControlFlow()
+                            addStatement(
+                                "return %T.failure(%T.NoMatchingError(error, ERRORS.map { it.abi }))",
+                                Result::class,
+                                ContractErrorDecodingError::class,
+                            )
                         }.build(),
                     )
                     .build(),
@@ -245,16 +280,48 @@ class AbiContractBuilder(
             )
 
             companion.addFunction(
-                FunSpec.builder("decodeEvent")
+                FunSpec.builder("decodeEventOrNull")
                     .addAnnotation(JvmStatic::class)
                     .addParameter("log", Log::class)
                     .returns(eventSuperclass.copy(nullable = true))
                     .addCode(
                         CodeBlock.builder().apply {
                             beginControlFlow("for (event in EVENTS)")
-                            addStatement("return event.decode(log) ?: continue")
+                            addStatement("return event.decodeOrNull(log) ?: continue")
                             endControlFlow()
                             addStatement("return null")
+                        }.build(),
+                    )
+                    .build(),
+            )
+
+            companion.addFunction(
+                FunSpec.builder("tryDecodeEvent")
+                    .addAnnotation(JvmStatic::class)
+                    .addParameter("log", Log::class)
+                    .returns(
+                        Result::class.asClassName().parameterizedBy(
+                            eventSuperclass,
+                            EventDecodingError::class.asClassName(),
+                        ),
+                    )
+                    .addCode(
+                        CodeBlock.builder().apply {
+                            beginControlFlow("for (event in EVENTS)")
+                            beginControlFlow("when (val decoded = event.tryDecode(log))")
+                            addStatement("is %T.Success -> return %T.success(decoded.value)", Result::class, Result::class)
+                            beginControlFlow("is %T.Failure ->", Result::class)
+                            beginControlFlow("if (decoded.error !is %T.NoMatchingEvent)", EventDecodingError::class)
+                            addStatement("return %T.failure(decoded.error)", Result::class)
+                            endControlFlow()
+                            endControlFlow()
+                            endControlFlow()
+                            endControlFlow()
+                            addStatement(
+                                "return %T.failure(%T.NoMatchingEvent(log, EVENTS.map { it.abi }))",
+                                Result::class,
+                                EventDecodingError::class,
+                            )
                         }.build(),
                     )
                     .build(),
@@ -613,6 +680,31 @@ class AbiContractBuilder(
             )
             .returns(errorClassName)
 
+        factoryBuilder.addFunction(
+            FunSpec.builder("decodeOrNull")
+                .addAnnotation(JvmStatic::class)
+                .addModifiers(KModifier.OVERRIDE)
+                .addParameter(ParameterSpec.builder("data", Bytes::class).build())
+                .addCode("return super.decodeOrNull(data)")
+                .returns(errorClassName.copy(nullable = true))
+                .build(),
+        )
+
+        factoryBuilder.addFunction(
+            FunSpec.builder("tryDecode")
+                .addAnnotation(JvmStatic::class)
+                .addModifiers(KModifier.OVERRIDE)
+                .addParameter(ParameterSpec.builder("data", Bytes::class).build())
+                .addCode("return super.tryDecode(data)")
+                .returns(
+                    Result::class.asClassName().parameterizedBy(
+                        errorClassName,
+                        ContractErrorDecodingError::class.asClassName(),
+                    ),
+                )
+                .build(),
+        )
+
         return CodeFactory.createClass(
             errorClassName,
             inputs,
@@ -724,12 +816,27 @@ class AbiContractBuilder(
 
         // override decode to make it statically accessible from java
         factoryBuilder.addFunction(
-            FunSpec.builder("decode")
+            FunSpec.builder("decodeOrNull")
                 .addAnnotation(JvmStatic::class)
                 .addModifiers(KModifier.OVERRIDE)
                 .addParameter(ParameterSpec.builder("log", Log::class).build())
-                .addCode("return super.decode(log)")
+                .addCode("return super.decodeOrNull(log)")
                 .returns(eventClassName.copy(nullable = true))
+                .build(),
+        )
+
+        factoryBuilder.addFunction(
+            FunSpec.builder("tryDecode")
+                .addAnnotation(JvmStatic::class)
+                .addModifiers(KModifier.OVERRIDE)
+                .addParameter(ParameterSpec.builder("log", Log::class).build())
+                .addCode("return super.tryDecode(log)")
+                .returns(
+                    Result::class.asClassName().parameterizedBy(
+                        eventClassName,
+                        EventDecodingError::class.asClassName(),
+                    ),
+                )
                 .build(),
         )
 

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/ErrorsTest.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/ErrorsTest.kt
@@ -63,7 +63,7 @@ class ErrorsTest : FunSpec({
                 listOf(detailsStruct1, detailsStruct2),
             )
 
-            structArgsError.decode(Bytes(encoded)) shouldBe expected
+            structArgsError.decodeOrNull(Bytes(encoded)) shouldBe expected
         }
 
         test("all factories have correct abi signature") {

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/EventsTest.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/cases/EventsTest.kt
@@ -70,7 +70,7 @@ class EventsTest : FunSpec({
                 false,
             )
 
-            val decoded = indexedAndDataArgsEvent.decode(log)
+            val decoded = indexedAndDataArgsEvent.decodeOrNull(log)
             val expected = eventClass.primaryConstructor!!.call(
                 topic1,
                 errorCode,

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/ERC1155.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/ERC1155.kt
@@ -7,10 +7,12 @@ import io.ethers.abi.AbiEvent
 import io.ethers.abi.AbiFunction
 import io.ethers.abi.AbiType
 import io.ethers.abi.ContractEvent
+import io.ethers.abi.EventDecodingError
 import io.ethers.abi.EventFactory
 import io.ethers.abi.EventFilter
 import io.ethers.abi.call.FunctionCall
 import io.ethers.abi.call.ReadFunctionCall
+import io.ethers.core.Result
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Log
@@ -279,7 +281,10 @@ public class ERC1155(
             override fun filter(provider: Middleware): EventFilter<ApprovalForAll> = EventFilter(provider, this)
 
             @JvmStatic
-            override fun decode(log: Log): ApprovalForAll? = super.decode(log)
+            override fun decodeOrNull(log: Log): ApprovalForAll? = super.decodeOrNull(log)
+
+            @JvmStatic
+            override fun tryDecode(log: Log): Result<ApprovalForAll, EventDecodingError> = super.tryDecode(log)
 
             @JvmStatic
             override fun decode(log: Log, `data`: List<Any>): ApprovalForAll = ApprovalForAll(
@@ -353,7 +358,10 @@ public class ERC1155(
             override fun filter(provider: Middleware): EventFilter<TransferBatch> = EventFilter(provider, this)
 
             @JvmStatic
-            override fun decode(log: Log): TransferBatch? = super.decode(log)
+            override fun decodeOrNull(log: Log): TransferBatch? = super.decodeOrNull(log)
+
+            @JvmStatic
+            override fun tryDecode(log: Log): Result<TransferBatch, EventDecodingError> = super.tryDecode(log)
 
             @JvmStatic
             override fun decode(log: Log, `data`: List<Any>): TransferBatch = TransferBatch(
@@ -429,7 +437,10 @@ public class ERC1155(
             override fun filter(provider: Middleware): EventFilter<TransferSingle> = EventFilter(provider, this)
 
             @JvmStatic
-            override fun decode(log: Log): TransferSingle? = super.decode(log)
+            override fun decodeOrNull(log: Log): TransferSingle? = super.decodeOrNull(log)
+
+            @JvmStatic
+            override fun tryDecode(log: Log): Result<TransferSingle, EventDecodingError> = super.tryDecode(log)
 
             @JvmStatic
             override fun decode(log: Log, `data`: List<Any>): TransferSingle = TransferSingle(
@@ -490,7 +501,10 @@ public class ERC1155(
             override fun filter(provider: Middleware): EventFilter<URI> = EventFilter(provider, this)
 
             @JvmStatic
-            override fun decode(log: Log): URI? = super.decode(log)
+            override fun decodeOrNull(log: Log): URI? = super.decodeOrNull(log)
+
+            @JvmStatic
+            override fun tryDecode(log: Log): Result<URI, EventDecodingError> = super.tryDecode(log)
 
             @JvmStatic
             override fun decode(log: Log, `data`: List<Any>): URI = URI(data[0] as kotlin.String, data[1] as io.github.artificialpb.bignum.BigInteger, log)
@@ -575,11 +589,26 @@ public class ERC1155(
             AbiFunction("supportsInterface", listOf(AbiType.FixedBytes(4)), listOf(AbiType.Bool))
 
         @JvmStatic
-        public fun decodeEvent(log: Log): ERC1155.Event? {
+        public fun decodeEventOrNull(log: Log): ERC1155.Event? {
             for (event in EVENTS) {
-                return event.decode(log) ?: continue
+                return event.decodeOrNull(log) ?: continue
             }
             return null
+        }
+
+        @JvmStatic
+        public fun tryDecodeEvent(log: Log): Result<ERC1155.Event, EventDecodingError> {
+            for (event in EVENTS) {
+                when (val decoded = event.tryDecode(log)) {
+                    is Result.Success -> return Result.success(decoded.value)
+                    is Result.Failure -> {
+                        if (decoded.error !is EventDecodingError.NoMatchingEvent) {
+                            return Result.failure(decoded.error)
+                        }
+                    }
+                }
+            }
+            return Result.failure(EventDecodingError.NoMatchingEvent(log, EVENTS.map { it.abi }))
         }
     }
 }

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/ERC721.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/ERC721.kt
@@ -7,11 +7,13 @@ import io.ethers.abi.AbiEvent
 import io.ethers.abi.AbiFunction
 import io.ethers.abi.AbiType
 import io.ethers.abi.ContractEvent
+import io.ethers.abi.EventDecodingError
 import io.ethers.abi.EventFactory
 import io.ethers.abi.EventFilter
 import io.ethers.abi.call.FunctionCall
 import io.ethers.abi.call.PayableFunctionCall
 import io.ethers.abi.call.ReadFunctionCall
+import io.ethers.core.Result
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Log
@@ -335,7 +337,10 @@ public class ERC721(
             override fun filter(provider: Middleware): EventFilter<Approval> = EventFilter(provider, this)
 
             @JvmStatic
-            override fun decode(log: Log): Approval? = super.decode(log)
+            override fun decodeOrNull(log: Log): Approval? = super.decodeOrNull(log)
+
+            @JvmStatic
+            override fun tryDecode(log: Log): Result<Approval, EventDecodingError> = super.tryDecode(log)
 
             @JvmStatic
             override fun decode(log: Log, `data`: List<Any>): Approval = Approval(data[0] as io.ethers.core.types.Address, data[1] as io.ethers.core.types.Address, data[2] as io.github.artificialpb.bignum.BigInteger, log)
@@ -388,7 +393,10 @@ public class ERC721(
             override fun filter(provider: Middleware): EventFilter<ApprovalForAll> = EventFilter(provider, this)
 
             @JvmStatic
-            override fun decode(log: Log): ApprovalForAll? = super.decode(log)
+            override fun decodeOrNull(log: Log): ApprovalForAll? = super.decodeOrNull(log)
+
+            @JvmStatic
+            override fun tryDecode(log: Log): Result<ApprovalForAll, EventDecodingError> = super.tryDecode(log)
 
             @JvmStatic
             override fun decode(log: Log, `data`: List<Any>): ApprovalForAll = ApprovalForAll(data[0] as io.ethers.core.types.Address, data[1] as io.ethers.core.types.Address, data[2] as kotlin.Boolean, log)
@@ -441,7 +449,10 @@ public class ERC721(
             override fun filter(provider: Middleware): EventFilter<Transfer> = EventFilter(provider, this)
 
             @JvmStatic
-            override fun decode(log: Log): Transfer? = super.decode(log)
+            override fun decodeOrNull(log: Log): Transfer? = super.decodeOrNull(log)
+
+            @JvmStatic
+            override fun tryDecode(log: Log): Result<Transfer, EventDecodingError> = super.tryDecode(log)
 
             @JvmStatic
             override fun decode(log: Log, `data`: List<Any>): Transfer = Transfer(data[0] as io.ethers.core.types.Address, data[1] as io.ethers.core.types.Address, data[2] as io.github.artificialpb.bignum.BigInteger, log)
@@ -522,11 +533,26 @@ public class ERC721(
             AbiFunction("supportsInterface", listOf(AbiType.FixedBytes(4)), listOf(AbiType.Bool))
 
         @JvmStatic
-        public fun decodeEvent(log: Log): ERC721.Event? {
+        public fun decodeEventOrNull(log: Log): ERC721.Event? {
             for (event in EVENTS) {
-                return event.decode(log) ?: continue
+                return event.decodeOrNull(log) ?: continue
             }
             return null
+        }
+
+        @JvmStatic
+        public fun tryDecodeEvent(log: Log): Result<ERC721.Event, EventDecodingError> {
+            for (event in EVENTS) {
+                when (val decoded = event.tryDecode(log)) {
+                    is Result.Success -> return Result.success(decoded.value)
+                    is Result.Failure -> {
+                        if (decoded.error !is EventDecodingError.NoMatchingEvent) {
+                            return Result.failure(decoded.error)
+                        }
+                    }
+                }
+            }
+            return Result.failure(EventDecodingError.NoMatchingEvent(log, EVENTS.map { it.abi }))
         }
     }
 }

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsMiddleware.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsMiddleware.kt
@@ -342,7 +342,7 @@ class EnsMiddleware @JvmOverloads constructor(
         }
 
         // If callbackResult is OffchainLookup error, resolve using recursive CCIP calls
-        val callbackLookupRevert = ExtendedResolver.OffchainLookup.decode(callbackResult)
+        val callbackLookupRevert = ExtendedResolver.OffchainLookup.decodeOrNull(callbackResult)
         if (callbackLookupRevert != null) {
             if (lookupLimit <= 0) return failure(Error.CcipLookupLimit)
 

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsRegistry.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsRegistry.kt
@@ -7,10 +7,12 @@ import io.ethers.abi.AbiEvent
 import io.ethers.abi.AbiFunction
 import io.ethers.abi.AbiType
 import io.ethers.abi.ContractEvent
+import io.ethers.abi.EventDecodingError
 import io.ethers.abi.EventFactory
 import io.ethers.abi.EventFilter
 import io.ethers.abi.call.FunctionCall
 import io.ethers.abi.call.ReadFunctionCall
+import io.ethers.core.Result
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.Log
@@ -254,7 +256,10 @@ public class EnsRegistry(
             override fun filter(provider: Middleware): EventFilter<ApprovalForAll> = EventFilter(provider, this)
 
             @JvmStatic
-            override fun decode(log: Log): ApprovalForAll? = super.decode(log)
+            override fun decodeOrNull(log: Log): ApprovalForAll? = super.decodeOrNull(log)
+
+            @JvmStatic
+            override fun tryDecode(log: Log): Result<ApprovalForAll, EventDecodingError> = super.tryDecode(log)
 
             @JvmStatic
             override fun decode(log: Log, `data`: List<Any>): ApprovalForAll = ApprovalForAll(data[0] as io.ethers.core.types.Address, data[1] as io.ethers.core.types.Address, data[2] as kotlin.Boolean, log)
@@ -307,7 +312,10 @@ public class EnsRegistry(
             override fun filter(provider: Middleware): EventFilter<NewOwner> = EventFilter(provider, this)
 
             @JvmStatic
-            override fun decode(log: Log): NewOwner? = super.decode(log)
+            override fun decodeOrNull(log: Log): NewOwner? = super.decodeOrNull(log)
+
+            @JvmStatic
+            override fun tryDecode(log: Log): Result<NewOwner, EventDecodingError> = super.tryDecode(log)
 
             @JvmStatic
             override fun decode(log: Log, `data`: List<Any>): NewOwner = NewOwner(data[0] as io.ethers.core.types.Bytes, data[1] as io.ethers.core.types.Bytes, data[2] as io.ethers.core.types.Address, log)
@@ -357,7 +365,10 @@ public class EnsRegistry(
             override fun filter(provider: Middleware): EventFilter<NewResolver> = EventFilter(provider, this)
 
             @JvmStatic
-            override fun decode(log: Log): NewResolver? = super.decode(log)
+            override fun decodeOrNull(log: Log): NewResolver? = super.decodeOrNull(log)
+
+            @JvmStatic
+            override fun tryDecode(log: Log): Result<NewResolver, EventDecodingError> = super.tryDecode(log)
 
             @JvmStatic
             override fun decode(log: Log, `data`: List<Any>): NewResolver = NewResolver(data[0] as io.ethers.core.types.Bytes, data[1] as io.ethers.core.types.Address, log)
@@ -407,7 +418,10 @@ public class EnsRegistry(
             override fun filter(provider: Middleware): EventFilter<NewTTL> = EventFilter(provider, this)
 
             @JvmStatic
-            override fun decode(log: Log): NewTTL? = super.decode(log)
+            override fun decodeOrNull(log: Log): NewTTL? = super.decodeOrNull(log)
+
+            @JvmStatic
+            override fun tryDecode(log: Log): Result<NewTTL, EventDecodingError> = super.tryDecode(log)
 
             @JvmStatic
             override fun decode(log: Log, `data`: List<Any>): NewTTL = NewTTL(data[0] as io.ethers.core.types.Bytes, data[1] as io.github.artificialpb.bignum.BigInteger, log)
@@ -457,7 +471,10 @@ public class EnsRegistry(
             override fun filter(provider: Middleware): EventFilter<Transfer> = EventFilter(provider, this)
 
             @JvmStatic
-            override fun decode(log: Log): Transfer? = super.decode(log)
+            override fun decodeOrNull(log: Log): Transfer? = super.decodeOrNull(log)
+
+            @JvmStatic
+            override fun tryDecode(log: Log): Result<Transfer, EventDecodingError> = super.tryDecode(log)
 
             @JvmStatic
             override fun decode(log: Log, `data`: List<Any>): Transfer = Transfer(data[0] as io.ethers.core.types.Bytes, data[1] as io.ethers.core.types.Address, log)
@@ -518,11 +535,26 @@ public class EnsRegistry(
             AbiFunction("setSubnodeRecord", listOf(AbiType.FixedBytes(32), AbiType.FixedBytes(32), AbiType.Address, AbiType.Address, AbiType.UInt(64)), listOf())
 
         @JvmStatic
-        public fun decodeEvent(log: Log): EnsRegistry.Event? {
+        public fun decodeEventOrNull(log: Log): EnsRegistry.Event? {
             for (event in EVENTS) {
-                return event.decode(log) ?: continue
+                return event.decodeOrNull(log) ?: continue
             }
             return null
+        }
+
+        @JvmStatic
+        public fun tryDecodeEvent(log: Log): Result<EnsRegistry.Event, EventDecodingError> {
+            for (event in EVENTS) {
+                when (val decoded = event.tryDecode(log)) {
+                    is Result.Success -> return Result.success(decoded.value)
+                    is Result.Failure -> {
+                        if (decoded.error !is EventDecodingError.NoMatchingEvent) {
+                            return Result.failure(decoded.error)
+                        }
+                    }
+                }
+            }
+            return Result.failure(EventDecodingError.NoMatchingEvent(log, EVENTS.map { it.abi }))
         }
     }
 }

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/ExtendedResolver.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/ExtendedResolver.kt
@@ -6,9 +6,11 @@ import io.ethers.abi.AbiContract
 import io.ethers.abi.AbiFunction
 import io.ethers.abi.AbiType
 import io.ethers.abi.call.ReadFunctionCall
+import io.ethers.abi.error.ContractErrorDecodingError
 import io.ethers.abi.error.CustomContractError
 import io.ethers.abi.error.CustomErrorFactory
 import io.ethers.abi.error.CustomErrorFactoryResolver
+import io.ethers.core.Result
 import io.ethers.core.types.Address
 import io.ethers.core.types.Bytes
 import io.ethers.providers.middleware.Middleware
@@ -174,11 +176,26 @@ public class ExtendedResolver(
         }
 
         @JvmStatic
-        public fun decodeError(error: Bytes): ExtendedResolver.Error? {
+        public fun decodeErrorOrNull(error: Bytes): ExtendedResolver.Error? {
             for (err in ERRORS) {
-                return err.decode(error) ?: continue
+                return err.decodeOrNull(error) ?: continue
             }
             return null
+        }
+
+        @JvmStatic
+        public fun tryDecodeError(error: Bytes): Result<ExtendedResolver.Error, ContractErrorDecodingError> {
+            for (err in ERRORS) {
+                when (val decoded = err.tryDecode(error)) {
+                    is Result.Success -> return Result.success(decoded.value)
+                    is Result.Failure -> {
+                        if (decoded.error !is ContractErrorDecodingError.NoMatchingError) {
+                            return Result.failure(decoded.error)
+                        }
+                    }
+                }
+            }
+            return Result.failure(ContractErrorDecodingError.NoMatchingError(error, ERRORS.map { it.abi }))
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds consumer-safe decoding APIs for contract events and contract errors:

- Adds `decodeOrNull`/`tryDecode` style APIs for event and custom error factories, collections, generated contract companions, and `Log` extensions.
- Keeps existing `decode` methods as nullable-compatible aliases that delegate to optimized `decodeOrNull` flows.
- Uses structured `Result` failures for explicit error reporting while keeping `orNull` paths allocation-light by avoiding `Result` and decoding-error construction.
- Extends abigen output and bumps the plugin output version.

## Why

Low-level ABI decoding can still throw, but higher-level consumer APIs should offer explicit non-throwing options. This gives consumers a choice between null-returning flows for fast matching and result-returning flows with failure context.

## Validation

- `./gradlew :ethers-abi:compileKotlinJvm :ethers-abi:compileTestKotlinJvm :ethers-abigen:compileKotlinJvm :ethers-abigen-plugin:compileKotlin`
- `./gradlew :ethers-abi:kotest :ethers-abigen:kotest ktlintCheck`