### PR TITLE
[codex] Fix websocket queued request timeouts

### DIFF
--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/WsClient.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/WsClient.kt
@@ -173,9 +173,6 @@ class WsClient(
 
             var requestId = 1L
             var msg: String?
-            var request: CompletableRequest<*>?
-            var batchRequest: CompletableBatchRequest?
-            var subscriptionRequest: CompletableSubscriptionRequest<*>?
             var unsubscribeRequestId: Long?
 
             var lastTimeoutCheck = TimeSource.Monotonic.markNow()
@@ -192,11 +189,16 @@ class WsClient(
                         }
                     }
 
+                    drainRequestQueuesToPending()
+
                     // second, check if we need to reconnect
                     if (reconnect.value) {
                         var reconnectSuccessful = false
 
                         while (!reconnectSuccessful && !stopping.value) {
+                            drainRequestQueuesToPending()
+                            handleTimeouts(readTimeoutMs.milliseconds)
+
                             LOG.dbg { "Trying to reconnect WebSocket" }
 
                             // cancel the old job (triggers finally → signals connectionClosedCondition)
@@ -215,8 +217,9 @@ class WsClient(
                             }
 
                             if (!reconnectSuccessful) {
+                                drainRequestQueuesToPending()
                                 handleTimeouts(readTimeoutMs.milliseconds)
-                                Thread.sleep(2000L)
+                                eventLock.withLock { newEventCondition.await(2000L, TimeUnit.MILLISECONDS) }
                             }
                         }
 
@@ -274,9 +277,6 @@ class WsClient(
                     }
 
                     // third, process all single and batch requests in the queue
-                    while (requestQueue.poll().also { request = it } != null) {
-                        pendingSendRequests.addLast(request!!)
-                    }
                     while (pendingSendRequests.isNotEmpty()) {
                         val pending = pendingSendRequests.first()
                         val id = requestId++
@@ -291,9 +291,6 @@ class WsClient(
                         }
                     }
 
-                    while (batchRequestQueue.poll().also { batchRequest = it } != null) {
-                        pendingSendBatchRequests.addLast(batchRequest!!)
-                    }
                     while (pendingSendBatchRequests.isNotEmpty()) {
                         val pending = pendingSendBatchRequests.first()
                         var batchId = -1L
@@ -325,9 +322,6 @@ class WsClient(
                     }
 
                     // fourth, process all subscription requests in the queue
-                    while (subscriptionQueue.poll().also { subscriptionRequest = it } != null) {
-                        pendingSendSubscriptionRequests.addLast(subscriptionRequest!!)
-                    }
                     while (pendingSendSubscriptionRequests.isNotEmpty()) {
                         val pending = pendingSendSubscriptionRequests.first()
                         val id = requestId++
@@ -391,6 +385,23 @@ class WsClient(
 
         processorThread.name = "WsClient-Processor-${processorThread.id}"
         processorThread.start()
+    }
+
+    private fun drainRequestQueuesToPending() {
+        var request: CompletableRequest<*>?
+        while (requestQueue.poll().also { request = it } != null) {
+            pendingSendRequests.addLast(request!!)
+        }
+
+        var batchRequest: CompletableBatchRequest?
+        while (batchRequestQueue.poll().also { batchRequest = it } != null) {
+            pendingSendBatchRequests.addLast(batchRequest!!)
+        }
+
+        var subscriptionRequest: CompletableSubscriptionRequest<*>?
+        while (subscriptionQueue.poll().also { subscriptionRequest = it } != null) {
+            pendingSendSubscriptionRequests.addLast(subscriptionRequest!!)
+        }
     }
 
     private fun handleTimeouts(timeout: Duration) {

--- a/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/WsClientTest.kt
+++ b/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/WsClientTest.kt
@@ -1,6 +1,7 @@
 package io.ethers.providers
 
 import io.ethers.core.Kotlinx
+import io.ethers.core.isFailure
 import io.ethers.core.isSuccess
 import io.ethers.core.types.Address
 import io.github.artificialpb.bignum.BigInteger
@@ -16,6 +17,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
 import org.intellij.lang.annotations.Language
+import java.util.concurrent.TimeUnit
 import kotlin.collections.mapOf
 import kotlin.time.Duration.Companion.seconds
 import io.ktor.client.HttpClient as KtorHttpClient
@@ -380,6 +382,32 @@ class WsClientTest : FunSpec({
 
             stream.isEmpty shouldBe true
             stream.isClosed shouldBe true
+        }
+
+        test("request queued during reconnect times out before reconnect succeeds") {
+            wsClient.close()
+            mockServer.allowReconnect()
+            wsClient = WsClient(
+                mockServer.url,
+                KtorHttpClient(CIO) { install(WebSockets) },
+                connectTimeoutMs = 50L,
+                readTimeoutMs = 100L,
+            )
+
+            val stringDecoder: (KJsonElement) -> String = { element -> element.jsonPrimitive.content }
+            mockServer.enqueueJson("""{"jsonrpc":"2.0","id":1,"result":"0x1234567"}""")
+            wsClient.request("eth_blockNumber", emptyArray<Any>(), stringDecoder)
+                .get(2, TimeUnit.SECONDS)
+                .isSuccess() shouldBe true
+
+            mockServer.closeConnection()
+            Thread.sleep(50)
+
+            val result = wsClient.request("eth_blockNumber", emptyArray<Any>(), stringDecoder)
+                .get(2, TimeUnit.SECONDS)
+
+            result.isFailure() shouldBe true
+            result.unwrapError().code shouldBe RpcError.CODE_CALL_TIMEOUT
         }
     }
 })


### PR DESCRIPTION
## Summary

Fixes a WebSocket timeout gap introduced by the Ktor migration follow-up: requests queued while `WsClient` is stuck reconnecting are now drained into the processor-owned pending queues, so they can expire even before a send succeeds.

## Root Cause

`request()`, `requestBatch()`, and `subscribe()` add work to inbound MPSC queues. During a reconnect outage, the processor stayed inside the reconnect loop and only called `handleTimeouts()` for in-flight and already-pending requests. New work left in the inbound queues was therefore invisible to timeout handling until reconnect succeeded.

## Changes

- Adds a `drainRequestQueuesToPending()` helper used before normal send processing and during reconnect retries.
- Replaces the fixed reconnect `Thread.sleep` backoff with the existing condition wait so new queued work wakes the processor.
- Adds a regression test covering a request queued during reconnect that must fail with `CODE_CALL_TIMEOUT` before reconnect succeeds.

## Validation

- `./gradlew :ethers-providers:kotest`
- `./gradlew :ethers-providers:ktlintCheck`