### PR TITLE
refactor: replace jctools with channels-kt

### DIFF
--- a/ethers-providers/build.gradle.kts
+++ b/ethers-providers/build.gradle.kts
@@ -15,7 +15,6 @@ kotlin {
                 api(libs.bignumkt)
 
                 implementation(project(":logger"))
-                implementation(libs.jctools)
                 implementation(libs.kotlinx.atomicfu)
             }
         }

--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/WsClient.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/WsClient.kt
@@ -35,8 +35,6 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
-import org.jctools.queues.MpscUnboundedXaddArrayQueue
-import org.jctools.queues.SpscUnboundedArrayQueue
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -86,12 +84,14 @@ class WsClient(
     private val connectionOpenedCondition = eventLock.newCondition()
     private val connectionClosedCondition = eventLock.newCondition()
 
-    // queues chosen based on https://vmlens.com/articles/scale/scalability_queue/
-    private val messageQueue = SpscUnboundedArrayQueue<String>(512)
-    private val requestQueue = MpscUnboundedXaddArrayQueue<PendingRequest<*>>(512)
-    private val batchRequestQueue = MpscUnboundedXaddArrayQueue<PendingBatchRequest>(256)
-    private val subscriptionQueue = MpscUnboundedXaddArrayQueue<PendingSubscriptionRequest<*>>(128)
-    private val unsubscribeQueue = MpscUnboundedXaddArrayQueue<Long>(128)
+    // WebSocket messages have one producer (the socket coroutine) and one consumer (the processor thread).
+    private val messageQueue = QueueChannel.spscUnbounded<String>()
+
+    // Requests may be submitted concurrently, but are all consumed by the processor thread.
+    private val requestQueue = QueueChannel.mpscUnbounded<PendingRequest<*>>()
+    private val batchRequestQueue = QueueChannel.mpscUnbounded<PendingBatchRequest>()
+    private val subscriptionQueue = QueueChannel.mpscUnbounded<PendingSubscriptionRequest<*>>()
+    private val unsubscribeQueue = QueueChannel.mpscUnbounded<Long>()
 
     private val reconnect = atomic(false)
     private val stopping = atomic(false)
@@ -119,7 +119,7 @@ class WsClient(
                     for (frame in incoming) {
                         when (frame) {
                             is Frame.Text -> {
-                                messageQueue.add(frame.readText())
+                                messageQueue.offer(frame.readText())
                                 eventLock.withLock { newEventCondition.signalAll() }
                             }
                             is Frame.Close -> {
@@ -233,7 +233,7 @@ class WsClient(
                             while (iter.hasNext()) {
                                 val value = iter.next().value
                                 LOG.dbg { "Re-queued in-flight request: $value" }
-                                requestQueue.add(value)
+                                requestQueue.offer(value)
                                 iter.remove()
                             }
                         }
@@ -244,7 +244,7 @@ class WsClient(
                             while (iter.hasNext()) {
                                 val (batchReq, _) = iter.next().value
                                 LOG.dbg { "Re-queued in-flight batch request: $batchReq" }
-                                batchRequestQueue.add(batchReq)
+                                batchRequestQueue.offer(batchReq)
                                 iter.remove()
                             }
                         }
@@ -255,7 +255,7 @@ class WsClient(
                             while (iter.hasNext()) {
                                 val value = iter.next().value
                                 LOG.dbg { "Re-queued in-flight subscription request: $value" }
-                                subscriptionQueue.add(value)
+                                subscriptionQueue.offer(value)
                                 iter.remove()
                             }
                         }
@@ -588,7 +588,7 @@ class WsClient(
                 params = request.params,
                 resultDecoder = request.resultDecoder,
                 stream = QueueChannel.spscUnbounded {
-                    unsubscribeQueue.add(id)
+                    unsubscribeQueue.offer(id)
                     eventLock.withLock { newEventCondition.signalAll() }
                 },
             )
@@ -647,7 +647,7 @@ class WsClient(
 
         val request = PendingBatchRequest(batch, CompletableDeferred())
 
-        batchRequestQueue.add(request)
+        batchRequestQueue.offer(request)
         eventLock.withLock { newEventCondition.signalAll() }
         return request.response.await()
     }
@@ -664,7 +664,7 @@ class WsClient(
             CompletableDeferred(),
         )
 
-        requestQueue.add(request)
+        requestQueue.offer(request)
         eventLock.withLock { newEventCondition.signalAll() }
         return request.response.await()
     }
@@ -679,7 +679,7 @@ class WsClient(
             CompletableDeferred(),
         )
 
-        subscriptionQueue.add(request)
+        subscriptionQueue.offer(request)
         eventLock.withLock { newEventCondition.signalAll() }
         return request.response.await()
     }

--- a/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/WsClient.kt
+++ b/ethers-providers/src/jvmSharedMain/kotlin/io/ethers/providers/WsClient.kt
@@ -119,7 +119,7 @@ class WsClient(
                     for (frame in incoming) {
                         when (frame) {
                             is Frame.Text -> {
-                                messageQueue.offer(frame.readText())
+                                messageQueue.enqueue(frame.readText())
                                 eventLock.withLock { newEventCondition.signalAll() }
                             }
                             is Frame.Close -> {
@@ -233,7 +233,7 @@ class WsClient(
                             while (iter.hasNext()) {
                                 val value = iter.next().value
                                 LOG.dbg { "Re-queued in-flight request: $value" }
-                                requestQueue.offer(value)
+                                requestQueue.enqueue(value)
                                 iter.remove()
                             }
                         }
@@ -244,7 +244,7 @@ class WsClient(
                             while (iter.hasNext()) {
                                 val (batchReq, _) = iter.next().value
                                 LOG.dbg { "Re-queued in-flight batch request: $batchReq" }
-                                batchRequestQueue.offer(batchReq)
+                                batchRequestQueue.enqueue(batchReq)
                                 iter.remove()
                             }
                         }
@@ -255,7 +255,7 @@ class WsClient(
                             while (iter.hasNext()) {
                                 val value = iter.next().value
                                 LOG.dbg { "Re-queued in-flight subscription request: $value" }
-                                subscriptionQueue.offer(value)
+                                subscriptionQueue.enqueue(value)
                                 iter.remove()
                             }
                         }
@@ -401,6 +401,10 @@ class WsClient(
         while (subscriptionQueue.poll().also { subscriptionRequest = it } != null) {
             pendingSendSubscriptionRequests.addLast(subscriptionRequest!!)
         }
+    }
+
+    private fun <T : Any> QueueChannel<T>.enqueue(element: T) {
+        check(offer(element)) { "Failed to enqueue element" }
     }
 
     private fun handleTimeouts(timeout: Duration) {
@@ -588,7 +592,7 @@ class WsClient(
                 params = request.params,
                 resultDecoder = request.resultDecoder,
                 stream = QueueChannel.spscUnbounded {
-                    unsubscribeQueue.offer(id)
+                    unsubscribeQueue.enqueue(id)
                     eventLock.withLock { newEventCondition.signalAll() }
                 },
             )
@@ -647,7 +651,7 @@ class WsClient(
 
         val request = PendingBatchRequest(batch, CompletableDeferred())
 
-        batchRequestQueue.offer(request)
+        batchRequestQueue.enqueue(request)
         eventLock.withLock { newEventCondition.signalAll() }
         return request.response.await()
     }
@@ -664,7 +668,7 @@ class WsClient(
             CompletableDeferred(),
         )
 
-        requestQueue.offer(request)
+        requestQueue.enqueue(request)
         eventLock.withLock { newEventCondition.signalAll() }
         return request.response.await()
     }
@@ -679,7 +683,7 @@ class WsClient(
             CompletableDeferred(),
         )
 
-        subscriptionQueue.offer(request)
+        subscriptionQueue.enqueue(request)
         eventLock.withLock { newEventCondition.signalAll() }
         return request.response.await()
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,6 @@ ethers-providers = { module = "io.kriptal.ethers:ethers-providers", version.ref 
 ethers-rlp = { module = "io.kriptal.ethers:ethers-signers", version.ref = "ethers" }
 ethers-signers = { module = "io.kriptal.ethers:ethers-signers", version.ref = "ethers" }
 
-jctools = { module = "org.jctools:jctools-core", version = "4.0.6" }
 channelskt-core = { module = "io.kriptal.channels:channels-core", version = "1.0.0" }
 
 log4j2-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j2" }


### PR DESCRIPTION
## Summary

- replace direct JCTools queues in `WsClient` with channels-kt `QueueChannel` implementations
- use an unbounded SPSC channel for WebSocket frames, which have one producer and one consumer
- use unbounded MPSC channels for requests, subscriptions, and unsubscribe signals, which may have multiple producers and one processor-thread consumer
- remove the direct JCTools dependency and version-catalog entry

## Rationale

The direct JCTools queue usage prevents moving `WsClient` toward Kotlin Multiplatform-compatible abstractions. The channels remain unbounded to preserve the existing delivery semantics: bounded non-blocking `offer` calls could drop frames or requests under load without a separate backpressure path.

## Validation

- `./gradlew :ethers-providers:jvmTest` (build successful; the `jvmTest` task is configured as skipped)
- `git diff --check`
- verified the JVM runtime dependency graph: JCTools is no longer declared directly by `ethers-providers` and remains only as channels-kt's JVM implementation detail