### PR TITLE
feat(ethers-providers): add native actuals for the platform seams

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-project-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-project-conventions.gradle.kts
@@ -69,7 +69,8 @@ pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
         // `java.*`. Compiling for a native target is the only thing that actually enforces it.
         //
         //   ./gradlew :ethers-core:compileKotlinIosSimulatorArm64 -PethersEnableIos
-        if (providers.gradleProperty("ethersEnableIos").isPresent) {
+        val iosEnabled = providers.gradleProperty("ethersEnableIos").isPresent
+        if (iosEnabled) {
             iosSimulatorArm64()
         }
 
@@ -128,6 +129,25 @@ pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
             }
             androidUnitTest {
                 dependsOn(jvmSharedTest)
+            }
+
+            // Intermediate source set for native targets, holding the `actual` declarations that cannot live in
+            // jvmSharedMain. Only created alongside the opt-in iOS target, so `src/nativeMain` is simply not
+            // compiled unless -PethersEnableIos is set.
+            if (iosEnabled) {
+                val nativeMain by creating {
+                    dependsOn(commonMain.get())
+                }
+                val nativeTest by creating {
+                    dependsOn(commonTest.get())
+                }
+
+                named("iosSimulatorArm64Main") {
+                    dependsOn(nativeMain)
+                }
+                named("iosSimulatorArm64Test") {
+                    dependsOn(nativeTest)
+                }
             }
         }
     }

--- a/ethers-providers/build.gradle.kts
+++ b/ethers-providers/build.gradle.kts
@@ -29,6 +29,12 @@ kotlin {
             }
         }
 
+        // only present when the opt-in iOS target is enabled (-PethersEnableIos)
+        findByName("nativeMain")?.dependencies {
+            // engine is selected per-platform via `defaultHttpClientEngineFactory`
+            api(libs.ktor.client.darwin)
+        }
+
         val jvmSharedTest by getting {
             dependencies {
                 implementation(libs.bundles.kotest)

--- a/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/WsClientTest.kt
+++ b/ethers-providers/src/jvmSharedTest/kotlin/io/ethers/providers/WsClientTest.kt
@@ -198,7 +198,11 @@ class WsClientTest : FunSpec({
             mockServer.sendJson(notification2)
             mockServer.sendJson(notification3)
 
-            // Verify all notifications are received in order
+            // Verify all notifications are received in order.
+            //
+            // Each notification is awaited separately: the three frames are written independently and there is no
+            // guarantee they are read and dispatched in a single batch, so asserting that later ones have already
+            // arrived just because the first has is a race - one that shows up on loaded CI machines.
 
             // First notification
             eventually(1.seconds) {
@@ -210,14 +214,18 @@ class WsClientTest : FunSpec({
             event1["timestamp"]?.jsonPrimitive?.content shouldBe "0x1111"
 
             // Second notification
-            stream.isEmpty shouldBe false
+            eventually(1.seconds) {
+                stream.isEmpty shouldBe false
+            }
             val event2 = stream.take()!!
             event2["number"]?.jsonPrimitive?.content shouldBe "0x1235"
             event2["hash"]?.jsonPrimitive?.content shouldBe "0xefgh"
             event2["timestamp"]?.jsonPrimitive?.content shouldBe "0x2222"
 
             // Third notification
-            stream.isEmpty shouldBe false
+            eventually(1.seconds) {
+                stream.isEmpty shouldBe false
+            }
             val event3 = stream.take()!!
             event3["number"]?.jsonPrimitive?.content shouldBe "0x1236"
             event3["hash"]?.jsonPrimitive?.content shouldBe "0xijkl"

--- a/ethers-providers/src/nativeMain/kotlin/io/ethers/providers/AsyncDispatcher.native.kt
+++ b/ethers-providers/src/nativeMain/kotlin/io/ethers/providers/AsyncDispatcher.native.kt
@@ -1,0 +1,14 @@
+package io.ethers.providers
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * Native targets have neither virtual threads nor a public `Dispatchers.IO` - it exists in kotlinx-coroutines but
+ * is declared `internal` for native - so provider tasks run on [Dispatchers.Default], a multi-threaded worker pool.
+ *
+ * The distinction matters less here than on the JVM: the Darwin engine is backed by NSURLSession, which completes
+ * requests on its own queues rather than by blocking the calling thread.
+ */
+internal actual val asyncDispatcher: CoroutineDispatcher
+    get() = Dispatchers.Default

--- a/ethers-providers/src/nativeMain/kotlin/io/ethers/providers/HttpClientEngine.native.kt
+++ b/ethers-providers/src/nativeMain/kotlin/io/ethers/providers/HttpClientEngine.native.kt
@@ -1,0 +1,11 @@
+package io.ethers.providers
+
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.darwin.Darwin
+
+/**
+ * Darwin is the ktor engine backed by NSURLSession, and is the only one available on Apple targets. It supports
+ * both HTTP and the WebSocket upgrade, which [WsClient] needs.
+ */
+internal actual val defaultHttpClientEngineFactory: HttpClientEngineFactory<*>
+    get() = Darwin

--- a/ethers-providers/src/nativeMain/kotlin/io/ethers/providers/PlatformProviderBuilder.native.kt
+++ b/ethers-providers/src/nativeMain/kotlin/io/ethers/providers/PlatformProviderBuilder.native.kt
@@ -1,0 +1,11 @@
+package io.ethers.providers
+
+import io.ethers.core.Result
+
+/**
+ * Native targets have no blocking terminal to expose, so this adds no members beyond the suspending [build] that
+ * [ProviderBuilder] implements.
+ */
+actual abstract class PlatformProviderBuilder actual constructor() {
+    actual abstract suspend fun build(): Result<Provider, Provider.Error>
+}

--- a/ethers-providers/src/nativeMain/kotlin/io/ethers/providers/types/PlatformBatchRpcRequest.native.kt
+++ b/ethers-providers/src/nativeMain/kotlin/io/ethers/providers/types/PlatformBatchRpcRequest.native.kt
@@ -1,0 +1,9 @@
+package io.ethers.providers.types
+
+/**
+ * Native targets have no blocking primitives to expose, so this adds no members beyond the suspending [send] that
+ * [BatchRpcRequest] implements.
+ */
+actual abstract class PlatformBatchRpcRequest actual constructor() {
+    actual abstract suspend fun send(): Boolean
+}

--- a/ethers-providers/src/nativeMain/kotlin/io/ethers/providers/types/PlatformBatchRpcResponse.native.kt
+++ b/ethers-providers/src/nativeMain/kotlin/io/ethers/providers/types/PlatformBatchRpcResponse.native.kt
@@ -1,0 +1,9 @@
+package io.ethers.providers.types
+
+/**
+ * Native targets have no blocking or [java.util.concurrent.CompletableFuture] primitives to expose, so this adds
+ * no members beyond the suspending [await] that [BatchRpcResponse] implements.
+ */
+actual abstract class PlatformBatchRpcResponse<T> actual constructor() {
+    actual abstract suspend fun await(): T
+}

--- a/ethers-providers/src/nativeMain/kotlin/io/ethers/providers/types/PlatformPendingInclusion.native.kt
+++ b/ethers-providers/src/nativeMain/kotlin/io/ethers/providers/types/PlatformPendingInclusion.native.kt
@@ -1,0 +1,18 @@
+package io.ethers.providers.types
+
+import io.ethers.core.Result
+import kotlin.time.Duration
+
+/**
+ * Native targets have no blocking or [java.util.concurrent.CompletableFuture] primitives to expose, so this adds
+ * no members beyond the suspending [inclusion] that [PendingInclusion] implements.
+ *
+ * Default argument values live on the `expect` declaration and must not be repeated here.
+ */
+actual interface PlatformPendingInclusion<T> {
+    actual suspend fun inclusion(
+        retries: Int,
+        interval: Duration,
+        confirmations: Int,
+    ): Result<T, PendingInclusion.Error>
+}

--- a/ethers-providers/src/nativeMain/kotlin/io/ethers/providers/types/PlatformRpcRequest.native.kt
+++ b/ethers-providers/src/nativeMain/kotlin/io/ethers/providers/types/PlatformRpcRequest.native.kt
@@ -1,0 +1,11 @@
+package io.ethers.providers.types
+
+import io.ethers.core.Result
+
+/**
+ * Native targets have no blocking or [java.util.concurrent.CompletableFuture] primitives to expose, so this adds
+ * no members beyond the suspending [send] that [RpcRequest] implements.
+ */
+actual abstract class PlatformRpcRequest<T, E : Result.Error> actual constructor() {
+    actual abstract suspend fun send(): Result<T, E>
+}

--- a/ethers-providers/src/nativeMain/kotlin/io/ethers/providers/types/PlatformRpcSubscribe.native.kt
+++ b/ethers-providers/src/nativeMain/kotlin/io/ethers/providers/types/PlatformRpcSubscribe.native.kt
@@ -1,0 +1,12 @@
+package io.ethers.providers.types
+
+import io.ethers.core.Result
+import io.channels.core.ChannelReceiver
+
+/**
+ * Native targets have no blocking primitives to expose, so this adds no members beyond the suspending [send] that
+ * [RpcSubscribe] implements.
+ */
+actual interface PlatformRpcSubscribe<T : Any, E : Result.Error> {
+    actual suspend fun send(): Result<ChannelReceiver<T>, E>
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,6 +60,7 @@ eclipse-collections-api = { module = "org.eclipse.collections:eclipse-collection
 
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-websockets = { module = "io.ktor:ktor-client-websockets", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version = "5.4.0" }


### PR DESCRIPTION
`ethers-providers` declared **eight `expect` declarations with no native `actual`**, which was the last thing keeping it from compiling off the JVM. This adds them, plus the `nativeMain` source set to hold them.

**No behaviour change on JVM or Android** — nothing outside `src/nativeMain` changes except the source-set wiring and one new dependency, both gated behind the opt-in flag.

## The six platform seams

`PlatformRpcRequest`, `PlatformRpcSubscribe`, `PlatformPendingInclusion`, `PlatformBatchRpcRequest`, `PlatformBatchRpcResponse`, `PlatformProviderBuilder`.

These exist so JVM callers get blocking and `CompletableFuture` helpers as inherited **members** rather than extension functions — `request.sendAwait()` instead of a static call. Native has neither primitive, so each actualizes with no members beyond the suspending one the common class already implements.

That is exactly what the seams were documented to do:

> JVM and Android actualize this with blocking and `CompletableFuture` variants. A platform without those primitives actualizes it with no extra members.

So these are mechanical, and the design decision behind them was already made.

## The two that are real choices

**`defaultHttpClientEngineFactory` → `Darwin`.** The NSURLSession-backed engine, and the only one available on Apple targets. It supports the WebSocket upgrade `WsClient` needs. Adds `io.ktor:ktor-client-darwin`, scoped to `nativeMain`.

**`asyncDispatcher` → `Dispatchers.Default`.** Native has no virtual threads, and `Dispatchers.IO` exists in kotlinx-coroutines but is declared `internal` for native — verified in the 1.10.2 sources, `nativeMain/Dispatchers.kt:22` — so there is no public equivalent to fall back to as the JVM actual does.

The distinction matters less than on the JVM: the Darwin engine completes requests on NSURLSession's own queues rather than by blocking the calling thread, so there is no blocking-IO pool to keep separate from CPU work.

## Source set

Adds a `nativeMain` intermediate that `dependsOn(commonMain)`, with `iosSimulatorArm64Main` depending on it. It is created **only** alongside the opt-in iOS target, so `src/nativeMain` is not compiled without `-PethersEnableIos`, and the normal build and publication are untouched. The Darwin dependency is wired via `findByName("nativeMain")?` for the same reason.

Naming it `nativeMain` rather than `iosMain` so future Apple or Linux targets share it without another move.

## Verification

```
./gradlew ktlintCheck test kotest                        # 798 tests, green
./gradlew :ethers-providers:compileKotlinIosSimulatorArm64 -PethersEnableIos
```

| Module | iOS |
| --- | --- |
| `logger`, `ethers-rlp`, `ethers-abigen`, `ethers-crypto`, `ethers-core`, `ethers-signers` | ✅ |
| **`ethers-providers`** | ✅ new |
| `ethers-abi` | ⛔️ |
| `ethers-ens` | ⛔️ blocked by `ethers-abi` |

**Seven of nine modules now compile for `iosSimulatorArm64`.**

## What this unblocks

`ethers-abi` has now been compiled for a native target for the first time, surfacing nine of its own errors. Two are the familiar import-free leakage (`kotlin.jvm.JvmSynthetic`, a bignum `toBigInteger`), but two need actual decisions:

- `sortedSetOf` (`EIP712Codec`, 2 sites) — `java.util.SortedSet` has no common equivalent
- `synchronized` (`CustomErrorRegistry`, 4 sites) — `kotlin.synchronized` is JVM-only; needs an atomicfu lock or a rethink of the registry's concurrency

`ethers-ens` is masked behind it and has still never been compiled for native, so more may follow.

## Not covered

Native **test** compilation. `compileTestKotlinIosSimulatorArm64` is untouched here — `commonTest` still reaches for MockWebServer and other JVM-only fixtures, which is a separate piece of work.
