### PR TITLE
refactor(ethers-abi): replace remaining JVM-only APIs in commonMain

### DIFF
--- a/ethers-abi/src/commonMain/kotlin/io/ethers/abi/call/AggregationResult.kt
+++ b/ethers-abi/src/commonMain/kotlin/io/ethers/abi/call/AggregationResult.kt
@@ -2,6 +2,7 @@ package io.ethers.abi.call
 
 import io.ethers.abi.error.ContractError
 import io.ethers.core.Result
+import kotlin.jvm.JvmSynthetic
 
 /**
  * Aggregation of multiple results, returned by [Multicall3] when aggregating multiple abi-generated calls.

--- a/ethers-abi/src/commonMain/kotlin/io/ethers/abi/call/Multicall3.kt
+++ b/ethers-abi/src/commonMain/kotlin/io/ethers/abi/call/Multicall3.kt
@@ -19,6 +19,7 @@ import io.ethers.core.types.IntoCallRequest
 import io.ethers.providers.middleware.Middleware
 import io.github.artificialpb.bignum.BigInteger
 import io.github.artificialpb.bignum.bigIntegerOf
+import io.github.artificialpb.bignum.plus
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
 import kotlin.jvm.JvmField

--- a/ethers-abi/src/commonMain/kotlin/io/ethers/abi/eip712/EIP712Codec.kt
+++ b/ethers-abi/src/commonMain/kotlin/io/ethers/abi/eip712/EIP712Codec.kt
@@ -170,15 +170,17 @@ object EIP712Codec {
      */
     @JvmOverloads
     fun encodeType(abi: AbiType.Struct<*>, builder: StringBuilder = StringBuilder()): String {
-        // ASC-sorted component types
-        val sortedComponents = getSortedComponents(abi)
+        val components = collectComponents(abi)
 
         // remove the root type so it's always first
-        sortedComponents.remove(abi.eip712RootType)
+        components.remove(abi.eip712RootType)
 
         // add the root type first
         builder.append(abi.eip712RootType)
-        for (component in sortedComponents) {
+
+        // EIP-712 requires the referenced struct types in ascending order. Sorting happens here rather than in the
+        // accumulator because kotlin has no sorted set in common code.
+        for (component in components.sorted()) {
             builder.append(component)
         }
 
@@ -203,8 +205,7 @@ object EIP712Codec {
         types: Map<String, List<EIP712Field>>,
         builder: StringBuilder = StringBuilder(),
     ): String {
-        // Get all dependent types in ASC-sorted order
-        val sortedComponents = getSortedComponents(primaryType, types)
+        val components = collectComponents(primaryType, types)
 
         // Build the primary type string first
         val primaryFields = types[primaryType]
@@ -213,12 +214,13 @@ object EIP712Codec {
         val primaryEip712Type = encodeRootType(primaryType, primaryFields)
 
         // remove the root type so it's always first
-        sortedComponents.remove(primaryEip712Type)
+        components.remove(primaryEip712Type)
 
         builder.append(primaryEip712Type)
 
-        // Add all dependent types in sorted order (excluding primary)
-        for (component in sortedComponents) {
+        // Add all dependent types in ascending order (excluding primary). Sorting happens here rather than in the
+        // accumulator because kotlin has no sorted set in common code.
+        for (component in components.sorted()) {
             builder.append(component)
         }
 
@@ -445,19 +447,19 @@ object EIP712Codec {
      * detection to prevent infinite recursion.
      *
      * @param type The ABI type to process
-     * @param components Accumulator for sorted component type strings
+     * @param components Accumulator for component type strings; callers sort the result
      * @param visiting Set to track currently visiting types for cycle detection
-     * @return Set of all component type strings in sorted order
+     * @return Set of all component type strings, in unspecified order
      * @throws IllegalStateException if circular references are detected
      */
-    private fun getSortedComponents(
+    private fun collectComponents(
         type: AbiType<*>,
-        components: MutableSet<String> = sortedSetOf(),
+        components: MutableSet<String> = mutableSetOf(),
         visiting: MutableSet<String> = mutableSetOf(),
     ): MutableSet<String> {
         return when (type) {
-            is AbiType.Array<*> -> getSortedComponents(type.type, components, visiting)
-            is AbiType.FixedArray<*> -> getSortedComponents(type.type, components, visiting)
+            is AbiType.Array<*> -> collectComponents(type.type, components, visiting)
+            is AbiType.FixedArray<*> -> collectComponents(type.type, components, visiting)
             is AbiType.Struct<*> -> {
                 // Check for cycles
                 if (!visiting.add(type.name)) {
@@ -467,7 +469,7 @@ object EIP712Codec {
                 components.add(type.eip712RootType)
 
                 for (field in type.fields) {
-                    getSortedComponents(field.type, components, visiting)
+                    collectComponents(field.type, components, visiting)
                 }
 
                 // Remove from the visiting set after processing
@@ -489,16 +491,16 @@ object EIP712Codec {
      *
      * @param primaryType The name of the primary struct type
      * @param types Map of type names to their field definitions
-     * @param components Accumulator for sorted component type strings
+     * @param components Accumulator for component type strings; callers sort the result
      * @param visiting Set to track currently visiting types for cycle detection
-     * @return Set of all component type strings in sorted order
+     * @return Set of all component type strings, in unspecified order
      * @throws IllegalArgumentException if a referenced type is not found
      * @throws IllegalStateException if circular references are detected
      */
-    private fun getSortedComponents(
+    private fun collectComponents(
         primaryType: String,
         types: Map<String, List<EIP712Field>>,
-        components: MutableSet<String> = sortedSetOf(),
+        components: MutableSet<String> = mutableSetOf(),
         visiting: MutableSet<String> = mutableSetOf(),
     ): MutableSet<String> {
         // Check for cycles
@@ -530,7 +532,7 @@ object EIP712Codec {
                     }
 
                     if (types.containsKey(baseType)) {
-                        getSortedComponents(baseType, types, components, visiting)
+                        collectComponents(baseType, types, components, visiting)
                     }
                 }
 
@@ -540,7 +542,7 @@ object EIP712Codec {
                         throw IllegalArgumentException("Type '$fieldType' not found in types map")
                     }
 
-                    getSortedComponents(fieldType, types, components, visiting)
+                    collectComponents(fieldType, types, components, visiting)
                 }
             }
         }

--- a/ethers-abi/src/commonMain/kotlin/io/ethers/abi/error/ContractError.kt
+++ b/ethers-abi/src/commonMain/kotlin/io/ethers/abi/error/ContractError.kt
@@ -7,6 +7,7 @@ import io.ethers.core.Result
 import io.ethers.core.types.Bytes
 import io.ethers.providers.RpcError
 import io.github.artificialpb.bignum.BigInteger
+import io.github.artificialpb.bignum.toBigInteger
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 

--- a/ethers-abi/src/commonMain/kotlin/io/ethers/abi/error/CustomErrorRegistry.kt
+++ b/ethers-abi/src/commonMain/kotlin/io/ethers/abi/error/CustomErrorRegistry.kt
@@ -3,6 +3,8 @@ package io.ethers.abi.error
 import io.ethers.abi.error.CustomErrorRegistry.appendResolver
 import io.ethers.abi.error.CustomErrorRegistry.prependResolver
 import io.ethers.core.types.Bytes
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 import kotlin.jvm.JvmStatic
 
 /**
@@ -13,6 +15,10 @@ import kotlin.jvm.JvmStatic
  * and the first resolver that can decode the error is used.
  * */
 object CustomErrorRegistry {
+    // `kotlin.synchronized` is JVM-only, so writes are guarded by an atomicfu lock instead. On the JVM this still
+    // compiles down to a monitor, so behaviour is unchanged.
+    private val lock = SynchronizedObject()
+
     private val resolvers = ArrayList<CustomErrorResolver>().apply {
         add(CustomErrorFactoryResolver)
     }
@@ -22,7 +28,7 @@ object CustomErrorRegistry {
      * */
     @JvmStatic
     fun prependResolver(resolver: CustomErrorResolver) {
-        synchronized(resolvers) {
+        synchronized(lock) {
             resolvers.add(0, resolver)
         }
     }
@@ -32,7 +38,7 @@ object CustomErrorRegistry {
      * */
     @JvmStatic
     fun appendResolver(resolver: CustomErrorResolver) {
-        synchronized(resolvers) {
+        synchronized(lock) {
             resolvers.add(resolver)
         }
     }
@@ -70,18 +76,20 @@ interface CustomErrorResolver {
  * errors are automatically added to this resolver.
  * */
 object CustomErrorFactoryResolver : CustomErrorResolver {
+    private val lock = SynchronizedObject()
+
     private val factories = ArrayList<CustomErrorFactory<*>>()
 
     @JvmStatic
     fun <T : CustomContractError> addFactories(newFactories: Array<CustomErrorFactory<out T>>) {
-        synchronized(factories) {
+        synchronized(lock) {
             factories.addAll(newFactories)
         }
     }
 
     @JvmStatic
     fun <T : CustomContractError> addFactories(newFactories: List<CustomErrorFactory<out T>>) {
-        synchronized(factories) {
+        synchronized(lock) {
             factories.addAll(newFactories)
         }
     }


### PR DESCRIPTION
Clears the last blockers in `ethers-abi`, which until now had never been compiled for a native target — it was masked behind `ethers-providers` failing first.

**No behaviour change on JVM or Android.**

## Three were import-only

The JVM either auto-imports these or provides them in its own stdlib, so their absence was invisible:

- **`@JvmSynthetic`** (`AggregationResult`) needed an explicit `kotlin.jvm` import — the same class of leakage as the 57 sites in #504. It resolves on the JVM without one and vanishes elsewhere.
- **`plus`** (`Multicall3`) and **`toBigInteger`** (`ContractError`) are bignum-kt top-level extensions that also resolve through kotlin-stdlib's `java.math` extensions on the JVM.

## `sortedSetOf` → sort at the point of use

`sortedSetOf()` is backed by `java.util.TreeSet` and has no common equivalent — Kotlin's common stdlib has no sorted set at all.

`EIP712Codec` used one as the accumulator while walking a struct's referenced types, relying on insertion-time ordering. It now collects into a plain set and the two call sites sort at the point of use, so `encodeType` still emits referenced struct types in ascending order as EIP-712 requires.

Output is unchanged: `TreeSet` orders by `compareTo` and `List.sorted()` uses the same natural `String` ordering, and the two dedupe identically for strings (`compareTo == 0` iff `equals` for `String`).

The recursive helper is renamed `getSortedComponents` → `collectComponents`, since it no longer returns sorted output and the old name would now be misleading.

This path is covered by the existing **"creates correct properly sorted string for multiple nested structs"** test, which asserts `Inbox(...)Mail(...)Person(...)` — a three-type ordering that genuinely exercises the sort rather than passing incidentally.

## `kotlin.synchronized` → atomicfu lock

`kotlin.synchronized` is JVM-only. `CustomErrorRegistry` and `CustomErrorFactoryResolver` now guard their writes with an atomicfu `SynchronizedObject`, which is **the approach `Multicall3` in this same module already uses** — so this follows existing precedent rather than introducing a new concurrency primitive. `ethers-abi` already depended on atomicfu.

On the JVM this still compiles down to a monitor, so behaviour is unchanged. Each object now holds its own lock instead of locking on the list it guards, which is also the safer habit.

## Verification

```
./gradlew ktlintCheck test kotest                  # 799 tests, green
./gradlew :ethers-abi:compileKotlinIosSimulatorArm64 -PethersEnableIos
```

| Module | iOS |
| --- | --- |
| `logger`, `ethers-rlp`, `ethers-abigen`, `ethers-crypto`, `ethers-core`, `ethers-signers`, `ethers-providers` | ✅ |
| **`ethers-abi`** | ✅ new |
| `ethers-ens` | ⛔️ |

**Eight of nine modules now compile for `iosSimulatorArm64`.**

## What's left

`ethers-ens` has now been compiled for a native target for the first time and surfaced seven errors, all in the ENSIP-15 normalization code:

- `ENSIP15.kt:373` and `ReadOnlyIntSet.kt:15` — a `compareTo` that needs an `operator` modifier, plus an unresolved overload alongside it
- `NF.kt:76` — an unresolved call whose type parameters can no longer be inferred

That is the last module, and unlike this one it looks like it needs actual reading rather than import hygiene.

Native **test** compilation remains untouched across all modules — `commonTest` still reaches for MockWebServer and other JVM-only fixtures.
