### PR TITLE
refactor(ethers-ens): replace remaining JVM-only APIs in commonMain

### DIFF
--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/normalize/ENSIP15.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/normalize/ENSIP15.kt
@@ -370,7 +370,7 @@ internal class ENSIP15(val nf: NF, dec: Decoder) {
                 } else {
                     var b = 0
                     for (i in 0 until bound) {
-                        if (comp.binarySearch(maker!![i]) >= 0) {
+                        if (comp.containsSorted(maker!![i])) {
                             maker[b++] = maker[i]
                         }
                     }

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/normalize/NF.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/normalize/NF.kt
@@ -73,7 +73,8 @@ internal class NF(dec: Decoder) {
 
         fun add(cp: Int) {
             var packed = cp
-            val cc = ranks.getOrDefault(cp, 0)
+            // `Map.getOrDefault` is JVM-only; ranks holds non-null Ints so an absent key is exactly a null lookup
+            val cc = ranks[cp] ?: 0
             if (cc != 0) {
                 check = true
                 packed = packed or cc

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/normalize/ReadOnlyIntSet.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/normalize/ReadOnlyIntSet.kt
@@ -12,7 +12,7 @@
 package io.ethers.ens.normalize
 
 internal class ReadOnlyIntSet private constructor(array: IntArray) : ReadOnlyIntList(array) {
-    override fun contains(value: Int): Boolean = array.binarySearch(value) >= 0
+    override fun contains(value: Int): Boolean = array.containsSorted(value)
 
     companion object {
         val EMPTY = ReadOnlyIntSet(IntArray(0))

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/normalize/SortedIntArray.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/normalize/SortedIntArray.kt
@@ -1,0 +1,29 @@
+package io.ethers.ens.normalize
+
+/**
+ * Membership test for an ascending-sorted [IntArray].
+ *
+ * The kotlin stdlib's `IntArray.binarySearch` is JVM-only - it delegates to `java.util.Arrays` - and has no common
+ * equivalent, so this reimplements it. Both call sites only ever compared the result against `>= 0`, so this
+ * returns a [Boolean] rather than an insertion point.
+ *
+ * The receiver **must** be sorted ascending; the result is undefined otherwise, exactly as with the stdlib version.
+ */
+internal fun IntArray.containsSorted(value: Int): Boolean {
+    var low = 0
+    var high = size - 1
+
+    while (low <= high) {
+        // `ushr` rather than `/ 2` so a large low + high cannot overflow into a negative index
+        val mid = (low + high) ushr 1
+        val midValue = this[mid]
+
+        when {
+            midValue < value -> low = mid + 1
+            midValue > value -> high = mid - 1
+            else -> return true
+        }
+    }
+
+    return false
+}

--- a/ethers-ens/src/commonTest/kotlin/io/ethers/ens/normalize/SortedIntArrayTest.kt
+++ b/ethers-ens/src/commonTest/kotlin/io/ethers/ens/normalize/SortedIntArrayTest.kt
@@ -1,0 +1,67 @@
+package io.ethers.ens.normalize
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.checkAll
+
+/**
+ * [containsSorted] replaces the JVM-only `IntArray.binarySearch`, so these pin the behaviour it has to reproduce.
+ */
+class SortedIntArrayTest : FunSpec({
+    context("finds values present in the array") {
+        withData(
+            nameFn = { "value ${it.second} in ${it.first.toList()}" },
+            intArrayOf(1) to 1,
+            intArrayOf(1, 2) to 1,
+            intArrayOf(1, 2) to 2,
+            intArrayOf(1, 3, 5, 7, 9) to 1, // first
+            intArrayOf(1, 3, 5, 7, 9) to 5, // middle
+            intArrayOf(1, 3, 5, 7, 9) to 9, // last
+            intArrayOf(-9, -5, 0, 5, 9) to -9,
+            intArrayOf(-9, -5, 0, 5, 9) to 0,
+            intArrayOf(Int.MIN_VALUE, 0, Int.MAX_VALUE) to Int.MIN_VALUE,
+            intArrayOf(Int.MIN_VALUE, 0, Int.MAX_VALUE) to Int.MAX_VALUE,
+        ) { (array, value) ->
+            array.containsSorted(value) shouldBe true
+        }
+    }
+
+    context("rejects values absent from the array") {
+        withData(
+            nameFn = { "value ${it.second} not in ${it.first.toList()}" },
+            IntArray(0) to 1,
+            intArrayOf(1) to 0,
+            intArrayOf(1) to 2,
+            intArrayOf(1, 3, 5, 7, 9) to 0, // below all
+            intArrayOf(1, 3, 5, 7, 9) to 4, // between
+            intArrayOf(1, 3, 5, 7, 9) to 10, // above all
+            intArrayOf(-9, -5, 0, 5, 9) to -7,
+            intArrayOf(Int.MIN_VALUE, Int.MAX_VALUE) to 0,
+        ) { (array, value) ->
+            array.containsSorted(value) shouldBe false
+        }
+    }
+
+    test("agrees with a linear scan for arbitrary sorted arrays") {
+        checkAll(Arb.list(Arb.int(-50..50), 0..40)) { values ->
+            val array = values.distinct().sorted().toIntArray()
+
+            // probe inside and outside the generated range, so both hits and misses are covered
+            for (probe in -55..55) {
+                array.containsSorted(probe) shouldBe array.contains(probe)
+            }
+        }
+    }
+
+    test("does not overflow on indices near Int.MAX_VALUE") {
+        // `(low + high)` would overflow to a negative index if it were not an unsigned shift. A real array that
+        // large is not allocatable here, so this covers the arithmetic directly.
+        val low = Int.MAX_VALUE - 1
+        val high = Int.MAX_VALUE
+        ((low + high) ushr 1) shouldBe 2147483646
+    }
+})


### PR DESCRIPTION
The last module. With this, **all nine modules compile for `iosSimulatorArm64`.**

**No behaviour change on JVM or Android.**

Three sites in the ENSIP-15 normalization code, and unlike the previous modules none of them was an import — they needed actual replacements.

## `IntArray.binarySearch` → `containsSorted`

JVM-only in the kotlin stdlib (it delegates to `java.util.Arrays`), with no common equivalent. Kotlin's common `binarySearch` only covers `List`, which is why the compiler reported the confusing *"'operator' modifier is required on `Comparable<T>.compareTo`"* — it had fallen through to a generic overload that doesn't fit.

Both call sites only ever compared the result against `>= 0`, so they move to a small `containsSorted` helper returning a `Boolean` rather than an insertion point.

It carries the same **"receiver must be sorted ascending"** precondition `binarySearch` had. I verified that holds at both sites rather than assuming it:

- `ReadOnlyIntSet` sorts in its `fromOwnedUnsorted` factory
- the confusable `complement` arrays are built with `.sorted().toIntArray()` in `ENSIP15`

## `Map.getOrDefault` → `?: 0`

Also JVM-only (a Java 8 default method). `ranks` is a `HashMap<Int, Int>` with non-null values, so an absent key is exactly a null lookup and the two are equivalent.

## Tests

The binary search is the **only genuinely new logic in this entire migration** — everything before it was substitution of equivalents — so it gets its own tests:

- boundary hits (first, middle, last, single-element)
- misses below, above and between elements, plus the empty array
- `Int.MIN_VALUE` / `Int.MAX_VALUE`
- a property test cross-checking against a linear scan over arbitrary sorted arrays
- one pinning the `ushr` that keeps the midpoint from overflowing to a negative index

22 cases, verified present in the test XML rather than inferred from a pass count.

The confusable path that consumes it is already covered by the existing ENSIP-15 conformance suite: **38,614 official vectors, 17,147 of which must error, 139 confusable-specific**, and it fails hard via `error(...)` on any mismatch. That is the real regression net here, and it passes.

## Verification

```
./gradlew ktlintCheck test kotest                  # 801 tests, green
./gradlew :ethers-ens:compileKotlinIosSimulatorArm64 -PethersEnableIos
```

| Module | iOS |
| --- | --- |
| `logger`, `ethers-rlp`, `ethers-abigen`, `ethers-crypto`, `ethers-core`, `ethers-signers`, `ethers-providers`, `ethers-abi` | ✅ |
| **`ethers-ens`** | ✅ new |

**Nine of nine.**

## What is still not done

Adding the iOS target for real is now a separate, deliberate decision — this PR does not do it. Two things stand between here and shipping one:

1. **Native test compilation.** `compileTestKotlinIosSimulatorArm64` has never been attempted in any module. `commonTest` still reaches for MockWebServer and other JVM-only fixtures, so an iOS target would currently ship with zero test coverage on that platform. This is the significant remaining piece.
2. **Target selection and publishing.** Only `iosSimulatorArm64` has been exercised. Real device (`iosArm64`) and Intel simulator (`iosX64`) are unverified — and `channels-kt` publishes no `iosX64`, so that one would fail to resolve today.
