### PR TITLE
refactor!: align null- and Result-returning APIs with the OrNull/try convention

### DIFF
--- a/ethers-abi/src/commonMain/kotlin/io/ethers/abi/call/ConstructorCall.kt
+++ b/ethers-abi/src/commonMain/kotlin/io/ethers/abi/call/ConstructorCall.kt
@@ -62,7 +62,7 @@ class ConstructorCall<T : AbiContract>(
         // - contracts that might have been created in the constructor,
         // - storage slots that might have been written in the constructor
         return provider.traceCall(call, blockId, config)
-            .mapError(::tryDecodingContractRevert)
+            .mapError(::decodeContractRevert)
             .andThen {
                 val overrides = it.toStateOverride()
                 val deployedBytecode = overrides[deployAddress]?.code ?: return@andThen failure(DeployError.NoBytecode)
@@ -118,7 +118,7 @@ class PayableConstructorCall<T : AbiContract>(
         // - contracts that might have been created in the constructor,
         // - storage slots that might have been written in the constructor
         return provider.traceCall(call, blockId, config)
-            .mapError(::tryDecodingContractRevert)
+            .mapError(::decodeContractRevert)
             .andThen {
                 val overrides = it.toStateOverride()
                 val deployedBytecode = overrides[deployAddress]?.code ?: return@andThen failure(DeployError.NoBytecode)

--- a/ethers-abi/src/commonMain/kotlin/io/ethers/abi/call/ContractCall.kt
+++ b/ethers-abi/src/commonMain/kotlin/io/ethers/abi/call/ContractCall.kt
@@ -5,6 +5,9 @@ import io.ethers.abi.error.ContractRpcError
 import io.ethers.abi.error.ExecutionRevertedError
 import io.ethers.abi.error.RevertError
 import io.ethers.core.FastHex
+import io.ethers.core.Result
+import io.ethers.core.ThrowableError
+import io.ethers.core.failure
 import io.ethers.core.types.AccessList
 import io.ethers.core.types.Address
 import io.ethers.core.types.BlockId
@@ -28,23 +31,61 @@ import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmSynthetic
 
 /**
+ * Error returned when signing a [ReadWriteContractCall] fails.
+ * */
+sealed class CallSigningError : ThrowableError {
+    /**
+     * The [call] is missing fields required to build a signable transaction.
+     * */
+    data class IncompleteCall(val call: CallRequest) : CallSigningError() {
+        override val message: String
+            get() = "Call is missing fields required for signing: $call"
+    }
+
+    /**
+     * The [Signer] failed to sign the transaction.
+     * */
+    data class SigningFailed(val error: Signer.SigningError) : CallSigningError() {
+        override val message: String
+            get() = error.message
+
+        override val cause: Throwable
+            get() = error.toException()
+    }
+}
+
+/**
  * Contract call that can be used to both read and write data to the blockchain.
  * */
 abstract class ReadWriteContractCall<C, S : PendingInclusion<*>, B : ReadWriteContractCall<C, S, B>>(
     provider: Middleware,
 ) : ReadContractCall<C, B>(provider) {
     /**
-     * Try to sign the call using the [signer]. If [call] does not have all the required fields set, the function
-     * returns null. The following fields must be set:
+     * Sign the call using the [signer], returning null if [call] does not have all the required fields set. The
+     * following fields must be set:
      * - [nonce]
      * - [gas]
      * - [gasPrice] or [gasFeeCap] + [gasTipCap]
      *
-     * @return [TransactionSigned], or null if [call] is not ready to be signed (missing some fields).
+     * If you need to know why signing failed, use [trySign].
+     *
+     * @return [TransactionSigned], or null if [call] is not ready to be signed or signing failed.
      * */
-    fun sign(signer: Signer): TransactionSigned? {
+    fun signOrNull(signer: Signer): TransactionSigned? {
         val tx = call.toUnsignedTransactionOrNull() ?: return null
-        return signer.signTransaction(tx)
+        return signer.trySignTransaction(tx).unwrapOrNull()
+    }
+
+    /**
+     * Try to sign the call using the [signer].
+     *
+     * Safe alternative to [signOrNull], which cannot tell an incomplete [call] apart from a signer failure.
+     *
+     * @return [TransactionSigned], or a [CallSigningError] if [call] is not ready to be signed or signing failed.
+     * */
+    fun trySign(signer: Signer): Result<TransactionSigned, CallSigningError> {
+        val tx = call.toUnsignedTransactionOrNull() ?: return failure(CallSigningError.IncompleteCall(call))
+        return signer.trySignTransaction(tx).mapError(CallSigningError::SigningFailed)
     }
 
     /**
@@ -70,13 +111,14 @@ abstract class ReadWriteContractCall<C, S : PendingInclusion<*>, B : ReadWriteCo
 
     /**
      * Sign the call using the [signer] and send it to the network. If call does not have all the required fields
-     * set (see [sign] function), it will be filled using [Middleware.fillTransaction] before signing and sending.
+     * set (see [signOrNull] function), it will be filled using [Middleware.fillTransaction] before signing and sending.
      * */
     fun send(signer: Signer): RpcRequest<S, RpcError> {
-        // if all params are set on "call", create signed tx directly
-        val signed = sign(signer)
-        if (signed != null) {
-            return provider.sendRawTransaction(signed).map(::handleSendResult)
+        // if all params are set on "call", create signed tx directly. Signing failures are propagated instead of
+        // falling back to "fillTransaction", which would only fail again after an extra round-trip.
+        val unsigned = call.toUnsignedTransactionOrNull()
+        if (unsigned != null) {
+            return provider.sendRawTransaction(signer.signTransaction(unsigned)).map(::handleSendResult)
         }
 
         // create a new copy to avoid modifying the original
@@ -179,7 +221,7 @@ abstract class ReadContractCall<C, B : ReadContractCall<C, B>>(
         return provider.traceCall(call, blockId, config)
     }
 
-    protected fun tryDecodingContractRevert(err: RpcError): ContractError {
+    protected fun decodeContractRevert(err: RpcError): ContractError {
         val isRevertMessage = err.message.contains("execution revert", true)
         if (err.isExecutionError || isRevertMessage) {
             when {

--- a/ethers-abi/src/commonMain/kotlin/io/ethers/abi/call/FunctionCall.kt
+++ b/ethers-abi/src/commonMain/kotlin/io/ethers/abi/call/FunctionCall.kt
@@ -48,7 +48,7 @@ class FunctionCall<T>(
         blockOverride: BlockOverride?,
     ): RpcRequest<T, ContractError> {
         return provider.call(call, blockId, stateOverride, blockOverride)
-            .mapError(::tryDecodingContractRevert)
+            .mapError(::decodeContractRevert)
             .andThen(::decodeCallResult)
     }
 
@@ -84,7 +84,7 @@ class ReadFunctionCall<T>(
         blockOverride: BlockOverride?,
     ): RpcRequest<T, ContractError> {
         return provider.call(call, blockId, stateOverride, blockOverride)
-            .mapError(::tryDecodingContractRevert)
+            .mapError(::decodeContractRevert)
             .andThen(::decodeCallResult)
     }
 
@@ -118,7 +118,7 @@ class PayableFunctionCall<T>(
         blockOverride: BlockOverride?,
     ): RpcRequest<T, ContractError> {
         return provider.call(call, blockId, stateOverride, blockOverride)
-            .mapError(::tryDecodingContractRevert)
+            .mapError(::decodeContractRevert)
             .andThen(::decodeCallResult)
     }
 
@@ -166,7 +166,7 @@ class ReceiveFunctionCall(
         blockOverride: BlockOverride?,
     ): RpcRequest<Unit, ContractError> {
         return provider.call(call, blockId, stateOverride, blockOverride)
-            .mapError(::tryDecodingContractRevert)
+            .mapError(::decodeContractRevert)
             .andThen(::decodeCallResult)
     }
 

--- a/ethers-abi/src/commonMain/kotlin/io/ethers/abi/call/Multicall3.kt
+++ b/ethers-abi/src/commonMain/kotlin/io/ethers/abi/call/Multicall3.kt
@@ -281,13 +281,13 @@ class Multicall3(
         val res = if (result.success) {
             request.decodeCallResult(result.returnData)
         } else {
-            failure(tryDecodingCallRevert(result.returnData))
+            failure(decodeCallRevert(result.returnData))
         }
 
         return res
     }
 
-    private fun tryDecodingCallRevert(err: Bytes): ContractError {
+    private fun decodeCallRevert(err: Bytes): ContractError {
         val contractError = ContractError.getOrNull(err)
         if (contractError != null) {
             return contractError

--- a/ethers-abi/src/commonMain/kotlin/io/ethers/abi/error/CustomErrorRegistry.kt
+++ b/ethers-abi/src/commonMain/kotlin/io/ethers/abi/error/CustomErrorRegistry.kt
@@ -59,7 +59,7 @@ object CustomErrorRegistry {
 
         for (i in resolvers.indices) {
             val customError = try {
-                resolvers[i].resolve(error)
+                resolvers[i].resolveOrNull(error)
             } catch (_: Exception) {
                 return null
             }
@@ -100,11 +100,16 @@ object CustomErrorRegistry {
  * Resolver for decoding [CustomContractError] from [Bytes].
  * */
 interface CustomErrorResolver {
-    fun resolve(error: Bytes): CustomContractError?
+    /**
+     * Decode [error] into a [CustomContractError], returning null if this resolver cannot decode it.
+     *
+     * If you need to know why decoding failed, use [tryResolve].
+     * */
+    fun resolveOrNull(error: Bytes): CustomContractError?
 
     fun tryResolve(error: Bytes): Result<CustomContractError, ContractErrorDecodingError> {
         return try {
-            resolve(error)?.let(::success)
+            resolveOrNull(error)?.let(::success)
                 ?: failure(ContractErrorDecodingError.NoMatchingError(error, emptyList()))
         } catch (e: Exception) {
             failure(ContractErrorDecodingError.MalformedError(error, null, e))
@@ -135,7 +140,7 @@ object CustomErrorFactoryResolver : CustomErrorResolver {
         }
     }
 
-    override fun resolve(error: Bytes): CustomContractError? {
+    override fun resolveOrNull(error: Bytes): CustomContractError? {
         if (error.size < 4) return null
 
         // the values are only appended to the end of the list, so we can safely iterate by index. Worst case,

--- a/ethers-abi/src/commonTest/kotlin/io/ethers/abi/call/CallSigningErrorTest.kt
+++ b/ethers-abi/src/commonTest/kotlin/io/ethers/abi/call/CallSigningErrorTest.kt
@@ -1,0 +1,48 @@
+package io.ethers.abi.call
+
+import io.ethers.core.ThrowableError
+import io.ethers.core.asTypeOrNull
+import io.ethers.core.types.CallRequest
+import io.ethers.signers.Signer
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class CallSigningErrorTest : FunSpec({
+    test("IncompleteCall names the call that could not be signed") {
+        val call = CallRequest().apply { gas = 21000L }
+        val error = CallSigningError.IncompleteCall(call)
+
+        error.call shouldBe call
+        error.message shouldContain "missing fields required for signing"
+
+        val exception = error.toException()
+        exception.toString() shouldContain "IncompleteCall"
+    }
+
+    test("SigningFailed keeps the SigningError and chains its exception") {
+        val cause = IllegalStateException("hardware wallet disconnected")
+        val signingError = Signer.SigningError("Error signing transaction: tx", cause)
+        val error = CallSigningError.SigningFailed(signingError)
+
+        // the cause stays a fully typed SigningError, not a flattened exception
+        error.error shouldBe signingError
+        error.message shouldBe "Error signing transaction: tx"
+
+        val exception = error.toException()
+        exception.message shouldBe "Error signing transaction: tx"
+        exception.cause.shouldBeInstanceOf<ThrowableError.Exception>().error shouldBe signingError
+    }
+
+    test("the two failure modes stay distinguishable through asTypeOrNull") {
+        val incomplete: ThrowableError = CallSigningError.IncompleteCall(CallRequest())
+        val failed: ThrowableError = CallSigningError.SigningFailed(Signer.SigningError("nope"))
+
+        incomplete.asTypeOrNull<CallSigningError.IncompleteCall>() shouldBe incomplete
+        incomplete.asTypeOrNull<CallSigningError.SigningFailed>() shouldBe null
+
+        failed.asTypeOrNull<CallSigningError.SigningFailed>() shouldBe failed
+        failed.asTypeOrNull<CallSigningError.IncompleteCall>() shouldBe null
+    }
+})

--- a/ethers-abi/src/commonTest/kotlin/io/ethers/abi/error/CustomErrorTest.kt
+++ b/ethers-abi/src/commonTest/kotlin/io/ethers/abi/error/CustomErrorTest.kt
@@ -102,7 +102,7 @@ class CustomErrorTest : FunSpec({
 
         val encoded = CollidingError.abi.encodeCall(listOf(bigIntegerOf(7)))
 
-        CustomErrorFactoryResolver.resolve(encoded) shouldBe CollidingError(bigIntegerOf(7))
+        CustomErrorFactoryResolver.resolveOrNull(encoded) shouldBe CollidingError(bigIntegerOf(7))
 
         // the Result-based path reports the first malformed match instead, since it can tell the two apart
         CustomErrorFactoryResolver.tryResolve(encoded)
@@ -128,7 +128,7 @@ class CustomErrorTest : FunSpec({
     }
 
     private class MockCustomErrorResolver : CustomErrorResolver {
-        override fun resolve(error: Bytes): CustomContractError? {
+        override fun resolveOrNull(error: Bytes): CustomContractError? {
             val err1 = ErrorWithStruct.decodeOrNull(error)
             if (err1 != null) {
                 return err1

--- a/ethers-abigen/src/jvmSharedMain/kotlin/io/ethers/abigen/reader/JsonAbiReader.kt
+++ b/ethers-abigen/src/jvmSharedMain/kotlin/io/ethers/abigen/reader/JsonAbiReader.kt
@@ -4,30 +4,39 @@ import io.ethers.abigen.JsonAbi
 import java.io.InputStream
 import java.net.URL
 
+/**
+ * Reader for a single ABI file format.
+ *
+ * A reader signals that it cannot handle the input by throwing - the built-in readers delegate format detection to
+ * the JSON deserializer and let its exception propagate. [JsonAbiReaderRegistry] catches it and moves on to the next
+ * reader, so throwing is how a reader says "not my format".
+ *
+ * This is why these functions are not named `readOrNull`: they never return null, they throw.
+ * */
 fun interface JsonAbiReader {
     /**
-     * Reads the ABI from the given [URL]. Returns null if the URL does not contain an ABI that this
-     * reader can read.
+     * Reads the ABI from the given [URL].
      *
-     * @return the ABI, or null if the URL does not contain an ABI that this reader can read.
+     * @return the ABI.
+     * @throws Exception if the URL does not contain an ABI that this reader can read.
      * */
-    fun read(abi: URL): JsonAbi? = read(abi.openStream())
+    fun read(abi: URL): JsonAbi = read(abi.openStream())
 
     /**
-     * Reads the ABI from the given [String]. Returns null if the string does not contain an ABI that this
-     * reader can read.
+     * Reads the ABI from the given [String].
      *
-     * @return the ABI, or null if the string does not contain an ABI that this reader can read.
+     * @return the ABI.
+     * @throws Exception if the string does not contain an ABI that this reader can read.
      * */
-    fun read(abi: String): JsonAbi? {
+    fun read(abi: String): JsonAbi {
         return read(abi.byteInputStream())
     }
 
     /**
-     * Reads the ABI from the given [InputStream]. Returns null if the stream does not contain an ABI that this
-     * reader can read.
+     * Reads the ABI from the given [InputStream].
      *
-     * @return the ABI, or null if the input stream does not contain an ABI that this reader can read.
+     * @return the ABI.
+     * @throws Exception if the stream does not contain an ABI that this reader can read.
      * */
-    fun read(abi: InputStream): JsonAbi?
+    fun read(abi: InputStream): JsonAbi
 }

--- a/ethers-abigen/src/jvmSharedMain/kotlin/io/ethers/abigen/reader/JsonAbiReaderRegistry.kt
+++ b/ethers-abigen/src/jvmSharedMain/kotlin/io/ethers/abigen/reader/JsonAbiReaderRegistry.kt
@@ -45,40 +45,40 @@ object JsonAbiReaderRegistry {
     /**
      * Read the ABI from the given [String]. Returns null if the source does not contain an ABI that any of the readers can read.
      *
-     * See [tryReadAbi] for a version that returns a [Result] with all errors instead.
+     * Exceptions thrown by the readers are swallowed and treated as "this reader cannot read the source".
+     * See [tryReadAbi] for a version that returns a [Result] with all of them instead.
      *
      * @return the [JsonAbi], or null if the source does not contain an ABI that any of the readers can read.
      * */
-    fun readAbi(abi: String): JsonAbi? {
-        return readAbi(abi.byteInputStream())
+    fun readAbiOrNull(abi: String): JsonAbi? {
+        return readAbiOrNull(abi.byteInputStream())
     }
 
     /**
      * Read the ABI from the given [URL]. Returns null if the source does not contain an ABI that any of the readers can read.
      *
-     * See [tryReadAbi] for a version that returns a [Result] with all errors instead.
+     * Exceptions thrown by the readers are swallowed and treated as "this reader cannot read the source".
+     * See [tryReadAbi] for a version that returns a [Result] with all of them instead.
      *
      * @return the [JsonAbi], or null if the source does not contain an ABI that any of the readers can read.
      * */
-    fun readAbi(abi: URL): JsonAbi? {
-        return readAbi(abi.openStream())
+    fun readAbiOrNull(abi: URL): JsonAbi? {
+        return readAbiOrNull(abi.openStream())
     }
 
     /**
      * Read the ABI from the given [InputStream]. Returns null if the source does not contain an ABI that any of the readers can read.
      *
-     * See [tryReadAbi] for a version that returns a [Result] with all errors instead.
+     * Exceptions thrown by the readers are swallowed and treated as "this reader cannot read the source".
+     * See [tryReadAbi] for a version that returns a [Result] with all of them instead.
      *
      * @return the [JsonAbi], or null if the source does not contain an ABI that any of the readers can read.
      * */
-    fun readAbi(abi: InputStream): JsonAbi? {
+    fun readAbiOrNull(abi: InputStream): JsonAbi? {
         val array = abi.readAllBytes()
         for (i in readers.indices) {
             try {
-                val jsonAbi = readers[i].read(ByteArrayInputStream(array))
-                if (jsonAbi != null) {
-                    return jsonAbi
-                }
+                return readers[i].read(ByteArrayInputStream(array))
             } catch (_: Exception) {
             }
         }
@@ -116,10 +116,7 @@ object JsonAbiReaderRegistry {
         var causes: MutableList<Exception>? = null
         for (i in readers.indices) {
             try {
-                val jsonAbi = readers[i].read(ByteArrayInputStream(array))
-                if (jsonAbi != null) {
-                    return success(jsonAbi)
-                }
+                return success(readers[i].read(ByteArrayInputStream(array)))
             } catch (e: Exception) {
                 if (causes == null) {
                     causes = ArrayList()

--- a/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/AbigenCompiler.kt
+++ b/ethers-abigen/src/jvmSharedTest/kotlin/io/ethers/abigen/AbigenCompiler.kt
@@ -44,7 +44,7 @@ object AbigenCompiler {
 
         val genSources = abis.map {
             val resourceName = it.name
-            val abi = JsonAbiReaderRegistry.readAbi(it.toURI().toURL())
+            val abi = JsonAbiReaderRegistry.readAbiOrNull(it.toURI().toURL())
                 ?: throw IllegalArgumentException("Invalid ABI: $resourceName")
 
             val contractName = resourceName.removeSuffix(".json").split("/").last()


### PR DESCRIPTION
Follow-up to #465. That PR established the `decodeOrNull` / `tryDecode` pairing in `ethers-abi`; an audit of the rest of the project turned up a handful of APIs that don't follow it.

## The convention being applied

| Shape | Meaning |
|---|---|
| `xOrNull` → `T?` | failure collapses to null, reason discarded |
| `tryX` → `Result<T, E>` | failure carries a typed reason |
| `x` → throws | failure raises |

`try` marks the safe alternative to an existing function of the same name — every `try*` in the codebase has such a counterpart, and every bare `Result`-returning function (`Address.fromHex`, `Avatar.parse`, `send`, `build`, …) lacks one. Those are left alone.

## Changes

**`JsonAbiReaderRegistry.readAbi` → `readAbiOrNull`** (3 overloads). It swallows every reader exception and returns null, with `tryReadAbi` as the informative sibling — it just wasn't named for it. Its docs now state the swallowing explicitly.

**`JsonAbiReader.read` keeps its name, but loses `?` from its return type.** It is *not* renamed to `readOrNull`: no implementation ever returns null. All four built-in readers delegate format detection to the JSON deserializer and let its exception propagate — that throw is what the registry catches to move to the next reader. The nullable type advertised a second failure channel that didn't exist, and the KDoc claiming "returns null if the reader can't read it" was simply wrong. Both are fixed.

**`CustomErrorResolver.resolve` → `resolveOrNull`**, which already had a `tryResolve` sibling.

**`ReadWriteContractCall.sign` → `signOrNull`, plus a new `trySign`.** The old `sign` conflated two failures: an incomplete call returned null, while a signer failure threw. `trySign` returns `Result<TransactionSigned, CallSigningError>`, where `CallSigningError` splits them into `IncompleteCall` and `SigningFailed` (the latter wrapping `Signer.SigningError` and chaining its exception per the `ThrowableError` contract).

**`tryDecodingContractRevert` / `tryDecodingCallRevert` → `decodeContractRevert` / `decodeCallRevert`.** Both are private/protected and return a `ContractError`, not a `Result`, so the `try` prefix was misleading. No API impact.

## Deliberately not changed

- **`Multicall3.tryAggregate` / `tryBlockAndAggregate`** — these are the Solidity method names of the contract, and the `Result` they return is `Multicall3.Result`, not `io.ethers.core.Result`. Noted in the commit message so they don't get "fixed" later.
- **`ExtendedResolver.resolve`** — a generated Solidity method.
- **`recover*` and `RlpDecodable.rlpDecode`** — also deviate (null-returning without the suffix), but `rlpDecode` alone is 18 declarations across an interface implemented 16 times. Larger, lower value, and better as its own change.

## Behaviour note

`send(signer)` used to call `sign(signer)` and fall back to `fillTransaction` when it returned null. Since `signOrNull` now also swallows signer failures, that fallback would have started firing on a broken signer — costing a round-trip before failing anyway. `send` now checks call completeness directly, so signer failures propagate exactly as before. No behaviour change.

## Testing

Adds `CallSigningErrorTest` (3 tests) covering the new error type's messages, typed-cause chaining, and `asTypeOrNull` discrimination, following the existing `EnsErrorTest` pattern.

`trySign` / `signOrNull` themselves are **not** covered end-to-end: constructing a `ReadWriteContractCall` needs a `Middleware` (~40 abstract members across five API interfaces), and mockk is JVM-only so it can't be used from `commonTest`. Flagging this as a known gap rather than papering over it.

- `./gradlew build kotest test` — 828 tests pass
- `ktlintFormat` / `ktlintCheck` clean
- `-PethersEnableIos` compile of `ethers-abi` and `ethers-ens` green

Note: the `ethers-providers` suite failed intermittently during full-build runs (a different test each time, all passing in isolation). It reproduces on clean `master`, and `ethers-providers` sits below the changed modules in the dependency graph, so it's unrelated pre-existing flakiness — but it will make CI noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kp9e86yZV5JkKsTY6p9tQn