### PR TITLE
refactor(ethers-ens)!: split EnsMiddleware into EnsResolver and a real interception middleware

### DIFF
--- a/ethers-ens/README.md
+++ b/ethers-ens/README.md
@@ -57,15 +57,19 @@ CallRequest().data(callData).toEns("vitalik.eth")            // wrap an existing
 There is deliberately no `to(Address)` builder — the recipient of an `EnsCallRequest` is always its ENS name. Use
 a plain `CallRequest` to target a raw address.
 
-Supported on `call`, `estimateGas`, `createAccessList`, `fillTransaction` and `traceCall`. Requests that are not
-an `EnsCallRequest` pass through untouched.
+Supported on `call`, `estimateGas`, `createAccessList`, `fillTransaction`, `traceCall`, `callMany` and
+`traceCallMany`. Requests that are not an `EnsCallRequest` pass through untouched.
 
 Two things to know:
 
 - `Middleware` fixes the error type to `RpcError`, so an ENS failure arrives as an `RpcError` with code
   `EnsMiddleware.CODE_ENS_RESOLUTION_FAILED` and the typed `EnsResolver.Error` as its `cause`. Reach for
   `EnsResolver` directly when you need the typed error.
-- `callMany` does not resolve names. Resolve them up front and pass plain call requests.
+- In the batch methods (`callMany`, `traceCallMany`) every name resolves concurrently — a batch exists to save
+  round trips, and resolving names one after another in front of it would cost more than it saves. A name that
+  cannot be resolved fails the **whole batch**, rather than becoming one failed entry: per-entry failures are
+  reported as `CallFailedError`, which carries only a string, and an unresolvable name is bad input rather than
+  an execution result.
 
 Passing an `EnsCallRequest` to a provider that is not wrapped in `EnsMiddleware` throws an `IllegalStateException`
 naming the fix, rather than silently sending a call with no recipient.

--- a/ethers-ens/README.md
+++ b/ethers-ens/README.md
@@ -1,0 +1,71 @@
+# ethers-ens
+
+Support for [ENS](https://docs.ens.domains/) name resolution, reverse resolution, text records, and avatars —
+including [wildcard resolution (ENSIP-10)](https://docs.ens.domains/ens-improvement-proposals/ensip-10-wildcard-resolution)
+and [CCIP-Read offchain resolution (ERC-3668)](https://eips.ethereum.org/EIPS/eip-3668).
+
+The module has two entry points.
+
+## `EnsResolver` — explicit resolution
+
+Use this when you want to resolve something and care about *why* it failed. Errors are typed as
+`EnsResolver.Error`.
+
+```kotlin
+val provider = Provider.builder("<URL>").buildAwait().unwrap()
+val ens = EnsResolver(provider)
+
+val address = ens.resolveAddress("vitalik.eth").sendAwait().unwrap()
+val twitter = ens.resolveText("vitalik.eth", "com.twitter").sendAwait().unwrap()
+val name = ens.resolveEnsName(address).sendAwait().unwrap()
+val avatar = ens.resolveAvatar("vitalik.eth").sendAwait().unwrap()
+```
+
+It also offers ENS-name overloads for the account-scoped RPC methods, which take a bare `Address` and so cannot
+be intercepted:
+
+```kotlin
+val balance = ens.getBalance("vitalik.eth", BlockId.LATEST).sendAwait().unwrap()
+val code = ens.getCode("vitalik.eth", BlockId.LATEST).sendAwait().unwrap()
+```
+
+Resolutions are cached for 5 minutes by default; pass a different `EnsNameCache` to change the ttl.
+
+## `EnsMiddleware` — ENS names in call requests
+
+Use this when you want to pass a name anywhere a call request is accepted. It is a real `Middleware` layer, so
+it composes with other layers and can be used as a drop-in provider.
+
+```kotlin
+val provider = EnsMiddleware(Provider.builder("<URL>").buildAwait().unwrap())
+
+val result = provider
+    .call(EnsCallRequest("vitalik.eth").data(callData), BlockId.LATEST)
+    .sendAwait()
+    .unwrap()
+```
+
+`EnsCallRequest` carries the same chaining builders as `CallRequest`, and can also be built with a lambda or by
+wrapping a request you already have:
+
+```kotlin
+EnsCallRequest("vitalik.eth").data(callData).value(amount)   // chained
+EnsCallRequest("vitalik.eth") { data = callData }            // builder lambda
+CallRequest().data(callData).toEns("vitalik.eth")            // wrap an existing request
+```
+
+There is deliberately no `to(Address)` builder — the recipient of an `EnsCallRequest` is always its ENS name. Use
+a plain `CallRequest` to target a raw address.
+
+Supported on `call`, `estimateGas`, `createAccessList`, `fillTransaction` and `traceCall`. Requests that are not
+an `EnsCallRequest` pass through untouched.
+
+Two things to know:
+
+- `Middleware` fixes the error type to `RpcError`, so an ENS failure arrives as an `RpcError` with code
+  `EnsMiddleware.CODE_ENS_RESOLUTION_FAILED` and the typed `EnsResolver.Error` as its `cause`. Reach for
+  `EnsResolver` directly when you need the typed error.
+- `callMany` does not resolve names. Resolve them up front and pass plain call requests.
+
+Passing an `EnsCallRequest` to a provider that is not wrapped in `EnsMiddleware` throws an `IllegalStateException`
+naming the fix, rather than silently sending a call with no recipient.

--- a/ethers-ens/build.gradle.kts
+++ b/ethers-ens/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
 
                 implementation(project(":logger"))
                 implementation(libs.kotlinx.atomicfu)
+                implementation(libs.kotlinx.coroutines.core)
             }
         }
 

--- a/ethers-ens/build.gradle.kts
+++ b/ethers-ens/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
                 api(libs.bignumkt)
 
                 implementation(project(":logger"))
+                implementation(libs.kotlinx.atomicfu)
             }
         }
 

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/Avatar.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/Avatar.kt
@@ -30,39 +30,39 @@ internal class AvatarNFT private constructor(
          *
          * Expected format: `eip155:<chainId>/<nftType>:<contractAddr>/<tokenId>`
          *
-         * Returns error [EnsMiddleware.Error.AvatarParsing].
+         * Returns error [EnsResolver.Error.AvatarParsing].
          */
-        fun parse(avatarUri: String): Result<AvatarNFT, EnsMiddleware.Error> {
+        fun parse(avatarUri: String): Result<AvatarNFT, EnsResolver.Error> {
             val withoutPrefix = avatarUri.removePrefix("eip155:")
             if (withoutPrefix == avatarUri) {
-                return failure(EnsMiddleware.Error.AvatarParsing("Unsupported URI link: $avatarUri", null))
+                return failure(EnsResolver.Error.AvatarParsing("Unsupported URI link: $avatarUri", null))
             }
 
             // Format: <chainId>/<nftType>:<contractAddr>/<tokenId>
             val parts = withoutPrefix.split("/")
             if (parts.size != 3) {
-                return failure(EnsMiddleware.Error.AvatarParsing("Unsupported URI link: $avatarUri", null))
+                return failure(EnsResolver.Error.AvatarParsing("Unsupported URI link: $avatarUri", null))
             }
 
             val chainId = runCatching { parts[0].toLong() }.unwrapOrReturn {
-                return failure(EnsMiddleware.Error.AvatarParsing("Invalid chain ID in URI: $avatarUri", it))
+                return failure(EnsResolver.Error.AvatarParsing("Invalid chain ID in URI: $avatarUri", it))
             }
 
             val typeAndAddr = parts[1].split(":")
             if (typeAndAddr.size != 2) {
-                return failure(EnsMiddleware.Error.AvatarParsing("Unsupported URI link: $avatarUri", null))
+                return failure(EnsResolver.Error.AvatarParsing("Unsupported URI link: $avatarUri", null))
             }
 
             val nftType = runCatching { AvatarNFTType.valueOf(typeAndAddr[0].uppercase()) }.unwrapOrReturn {
-                return failure(EnsMiddleware.Error.AvatarParsing("Unsupported URI token type: ${typeAndAddr[0]}", it))
+                return failure(EnsResolver.Error.AvatarParsing("Unsupported URI token type: ${typeAndAddr[0]}", it))
             }
 
             val nftAddr = runCatching { Address(typeAndAddr[1]) }.unwrapOrReturn {
-                return failure(EnsMiddleware.Error.AvatarParsing("Invalid URI NFT contract address: ${typeAndAddr[1]}", it))
+                return failure(EnsResolver.Error.AvatarParsing("Invalid URI NFT contract address: ${typeAndAddr[1]}", it))
             }
 
             val tokenId = runCatching { BigInteger(parts[2]) }.unwrapOrReturn {
-                return failure(EnsMiddleware.Error.AvatarParsing("Unsupported URI token id type: ${parts[2]}", it))
+                return failure(EnsResolver.Error.AvatarParsing("Unsupported URI token id type: ${parts[2]}", it))
             }
 
             return success(AvatarNFT(chainId, nftType, nftAddr, tokenId))

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsCallRequest.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsCallRequest.kt
@@ -1,0 +1,95 @@
+package io.ethers.ens
+
+import io.ethers.core.types.AccessList
+import io.ethers.core.types.Address
+import io.ethers.core.types.Bytes
+import io.ethers.core.types.CallRequest
+import io.ethers.core.types.Hash
+import io.ethers.core.types.IntoCallRequest
+import io.github.artificialpb.bignum.BigInteger
+import kotlin.jvm.JvmOverloads
+
+/**
+ * A call request whose recipient is an ENS name that has not been resolved yet.
+ *
+ * ENS resolution needs network access and can fail, but [IntoCallRequest.toCallRequest] is synchronous and
+ * infallible. Resolution therefore happens one level up, in [EnsMiddleware], and this type exists only to carry
+ * the unresolved name to it:
+ *
+ * ```kotlin
+ * val provider = EnsMiddleware(Provider.builder(url).buildAwait().unwrap())
+ *
+ * // build it directly...
+ * provider.call(EnsCallRequest("vitalik.eth").data(callData), BlockId.LATEST).sendAwait()
+ *
+ * // ...with a builder lambda...
+ * provider.call(EnsCallRequest("vitalik.eth") { data = callData }, BlockId.LATEST).sendAwait()
+ *
+ * // ...or wrap a CallRequest you already have
+ * provider.call(CallRequest().data(callData).toEns("vitalik.eth"), BlockId.LATEST).sendAwait()
+ * ```
+ *
+ * The recipient is always the ENS name, so there is deliberately no `to(Address)` builder - use a plain
+ * [CallRequest] to target a raw address.
+ *
+ * Passing one to a plain [io.ethers.providers.Provider] throws from [toCallRequest] rather than silently
+ * producing a call with no recipient.
+ * */
+class EnsCallRequest @JvmOverloads constructor(
+    val toEnsName: String,
+    request: CallRequest = CallRequest(),
+) : IntoCallRequest {
+    // defensive copy - callers must not be able to mutate the request after it has been handed over
+    private val request = CallRequest(request)
+
+    override fun toCallRequest(): CallRequest {
+        throw IllegalStateException(
+            "Call to ENS name '$toEnsName' reached a provider that cannot resolve it. " +
+                "Wrap your provider in EnsMiddleware: EnsMiddleware(provider).",
+        )
+    }
+
+    /**
+     * Get a plain [CallRequest] for this request, with [address] as the recipient.
+     * */
+    internal fun resolveTo(address: Address): CallRequest = CallRequest(request).to(address)
+
+    //-----------------------------------------------------------------------------------------------------------------
+    //                                  Builders
+    //
+    // These mirror CallRequest's chaining builders one-for-one, minus to(Address). EnsCallRequestParityTest
+    // fails if CallRequest gains or changes one and this list is not updated to match.
+    //-----------------------------------------------------------------------------------------------------------------
+    fun from(from: Address?) = apply { request.from = from }
+    fun gas(gas: Long) = apply { request.gas = gas }
+    fun gasPrice(gasPrice: BigInteger?) = apply { request.gasPrice = gasPrice }
+    fun gasFeeCap(gasFeeCap: BigInteger?) = apply { request.gasFeeCap = gasFeeCap }
+    fun gasTipCap(gasTipCap: BigInteger?) = apply { request.gasTipCap = gasTipCap }
+    fun value(value: BigInteger?) = apply { request.value = value }
+    fun nonce(nonce: Long) = apply { request.nonce = nonce }
+    fun data(data: Bytes?) = apply { request.data = data }
+    fun accessList(accessList: List<AccessList.Item>) = apply { request.accessList = accessList }
+    fun chainId(chainId: Long) = apply { request.chainId = chainId }
+    fun blobFeeCap(blobFeeCap: BigInteger?) = apply { request.blobFeeCap = blobFeeCap }
+    fun blobVersionedHashes(blobVersionedHashes: List<Hash>?) = apply {
+        request.blobVersionedHashes = blobVersionedHashes
+    }
+
+    override fun toString(): String = "EnsCallRequest(toEnsName=$toEnsName, request=$request)"
+
+    companion object {
+        /**
+         * Build an [EnsCallRequest] for [ensName], configuring the underlying request with [builder].
+         * */
+        inline operator fun invoke(ensName: String, builder: CallRequest.() -> Unit): EnsCallRequest {
+            return EnsCallRequest(ensName, CallRequest().apply(builder))
+        }
+    }
+}
+
+/**
+ * Wrap `this` call request so that it is sent to [ensName] instead of a raw address, resolved by [EnsMiddleware].
+ *
+ * The request is copied, so later changes to `this` do not affect the returned [EnsCallRequest].
+ * */
+fun CallRequest.toEns(ensName: String): EnsCallRequest = EnsCallRequest(ensName, this)

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsCallRequest.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsCallRequest.kt
@@ -7,7 +7,6 @@ import io.ethers.core.types.CallRequest
 import io.ethers.core.types.Hash
 import io.ethers.core.types.IntoCallRequest
 import io.github.artificialpb.bignum.BigInteger
-import kotlin.jvm.JvmOverloads
 
 /**
  * A call request whose recipient is an ENS name that has not been resolved yet.
@@ -35,16 +34,23 @@ import kotlin.jvm.JvmOverloads
  * Passing one to a plain [io.ethers.providers.Provider] throws from [toCallRequest] rather than silently
  * producing a call with no recipient.
  * */
-class EnsCallRequest @JvmOverloads constructor(
-    val toEnsName: String,
-    request: CallRequest = CallRequest(),
-) : IntoCallRequest {
-    // defensive copy - callers must not be able to mutate the request after it has been handed over
-    private val request = CallRequest(request)
+class EnsCallRequest : IntoCallRequest {
+    val toEns: String
+    private val request: CallRequest
+
+    constructor(toEns: String, request: CallRequest) {
+        this.toEns = toEns
+        this.request = CallRequest(request)
+    }
+
+    constructor(toEns: String) {
+        this.toEns = toEns
+        this.request = CallRequest()
+    }
 
     override fun toCallRequest(): CallRequest {
         throw IllegalStateException(
-            "Call to ENS name '$toEnsName' reached a provider that cannot resolve it. " +
+            "Call to ENS name '$toEns' reached a provider that cannot resolve it. " +
                 "Wrap your provider in EnsMiddleware: EnsMiddleware(provider).",
         )
     }
@@ -75,14 +81,18 @@ class EnsCallRequest @JvmOverloads constructor(
         request.blobVersionedHashes = blobVersionedHashes
     }
 
-    override fun toString(): String = "EnsCallRequest(toEnsName=$toEnsName, request=$request)"
+    override fun toString(): String = "EnsCallRequest(toEns=$toEns, request=$request)"
 
     companion object {
         /**
          * Build an [EnsCallRequest] for [ensName], configuring the underlying request with [builder].
          * */
-        inline operator fun invoke(ensName: String, builder: CallRequest.() -> Unit): EnsCallRequest {
-            return EnsCallRequest(ensName, CallRequest().apply(builder))
+        operator fun invoke(ensName: String, builder: CallRequest.() -> Unit): EnsCallRequest {
+            // configure the request in place rather than building one and handing it to the copying constructor -
+            // nothing else holds a reference to it, so there is nothing to defend against
+            val call = EnsCallRequest(ensName)
+            call.request.builder()
+            return call
         }
     }
 }

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsMiddleware.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsMiddleware.kt
@@ -1,5 +1,7 @@
 package io.ethers.ens
 
+import io.ethers.core.Result
+import io.ethers.core.failure
 import io.ethers.core.success
 import io.ethers.core.types.BlockId
 import io.ethers.core.types.BlockOverride
@@ -10,10 +12,15 @@ import io.ethers.core.types.IntoCallRequest
 import io.ethers.core.types.StateOverride
 import io.ethers.core.types.tracers.TracerConfig
 import io.ethers.core.types.transaction.TransactionUnsigned
+import io.ethers.core.unwrapOrReturn
 import io.ethers.providers.RpcError
 import io.ethers.providers.middleware.Middleware
+import io.ethers.providers.types.CallFailedError
 import io.ethers.providers.types.RpcRequest
 import io.ethers.providers.types.SuppliedRpcRequest
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 
 /**
  * A [Middleware] layer that accepts an [EnsCallRequest] anywhere a call request is expected, resolves its ENS
@@ -30,8 +37,8 @@ import io.ethers.providers.types.SuppliedRpcRequest
  * [RpcError] with code [CODE_ENS_RESOLUTION_FAILED] and the typed [EnsResolver.Error] as their cause. Use [ens]
  * directly when you need the typed error.
  *
- * Note that [callMany] does not resolve ENS names: it takes a list of call requests, and resolving each element
- * is not yet supported. Resolve the names up front with [ens] and pass plain call requests instead.
+ * The batch methods [callMany] and [traceCallMany] resolve every name in the list concurrently, and a name that
+ * cannot be resolved fails the whole batch rather than being reported as a single failed entry.
  * */
 class EnsMiddleware(
     override val inner: Middleware,
@@ -163,6 +170,101 @@ class EnsMiddleware(
     override fun <T : Any> traceCall(call: IntoCallRequest, blockNumber: Long, config: TracerConfig<T>) = traceCall(call, BlockId.Number(blockNumber), config)
 
     override fun <T : Any> traceCall(call: IntoCallRequest, blockHash: Hash, config: TracerConfig<T>) = traceCall(call, BlockId.Hash(blockHash), config)
+
+    /**
+     * Resolve the recipient of every [EnsCallRequest] in [calls], leaving the other entries untouched and
+     * preserving order.
+     *
+     * Names are resolved concurrently: a batch exists to save round trips, and resolving N names one after
+     * another in front of it would cost more than it saves.
+     *
+     * A name that cannot be resolved fails the whole batch. Per-entry failures would have to be reported as
+     * [CallFailedError], which carries only a string and would make an unresolvable name indistinguishable from
+     * a reverted call - an unresolvable name is bad input, not an execution result.
+     * */
+    private suspend fun resolveRecipients(calls: List<IntoCallRequest>): Result<List<IntoCallRequest>, RpcError> {
+        if (calls.none { it is EnsCallRequest }) {
+            return success(calls)
+        }
+
+        val resolved = coroutineScope {
+            calls.map { call ->
+                async {
+                    if (call is EnsCallRequest) resolveRecipient(call).send() else success(call)
+                }
+            }.awaitAll()
+        }
+
+        val out = ArrayList<IntoCallRequest>(calls.size)
+        for (result in resolved) {
+            out.add(result.unwrapOrReturn { return failure(it) })
+        }
+
+        return success(out)
+    }
+
+    override fun callMany(
+        blockId: BlockId,
+        calls: List<IntoCallRequest>,
+        transactionIndex: Int,
+        stateOverride: StateOverride?,
+        blockOverride: BlockOverride?,
+    ): RpcRequest<List<Result<Bytes, CallFailedError>>, RpcError> {
+        if (calls.none { it is EnsCallRequest }) {
+            return inner.callMany(blockId, calls, transactionIndex, stateOverride, blockOverride)
+        }
+
+        return SuppliedRpcRequest {
+            val resolved = resolveRecipients(calls).unwrapOrReturn { return@SuppliedRpcRequest failure(it) }
+            inner.callMany(blockId, resolved, transactionIndex, stateOverride, blockOverride).send()
+        }
+    }
+
+    override fun callMany(
+        blockNumber: Long,
+        calls: List<IntoCallRequest>,
+        transactionIndex: Int,
+        stateOverride: StateOverride?,
+        blockOverride: BlockOverride?,
+    ) = callMany(BlockId.Number(blockNumber), calls, transactionIndex, stateOverride, blockOverride)
+
+    override fun callMany(
+        blockHash: Hash,
+        calls: List<IntoCallRequest>,
+        transactionIndex: Int,
+        stateOverride: StateOverride?,
+        blockOverride: BlockOverride?,
+    ) = callMany(BlockId.Hash(blockHash), calls, transactionIndex, stateOverride, blockOverride)
+
+    override fun <T : Any> traceCallMany(
+        blockId: BlockId,
+        calls: List<IntoCallRequest>,
+        config: TracerConfig<T>,
+        transactionIndex: Int,
+    ): RpcRequest<List<T>, RpcError> {
+        if (calls.none { it is EnsCallRequest }) {
+            return inner.traceCallMany(blockId, calls, config, transactionIndex)
+        }
+
+        return SuppliedRpcRequest {
+            val resolved = resolveRecipients(calls).unwrapOrReturn { return@SuppliedRpcRequest failure(it) }
+            inner.traceCallMany(blockId, resolved, config, transactionIndex).send()
+        }
+    }
+
+    override fun <T : Any> traceCallMany(
+        blockNumber: Long,
+        calls: List<IntoCallRequest>,
+        config: TracerConfig<T>,
+        transactionIndex: Int,
+    ) = traceCallMany(BlockId.Number(blockNumber), calls, config, transactionIndex)
+
+    override fun <T : Any> traceCallMany(
+        blockHash: Hash,
+        calls: List<IntoCallRequest>,
+        config: TracerConfig<T>,
+        transactionIndex: Int,
+    ) = traceCallMany(BlockId.Hash(blockHash), calls, config, transactionIndex)
 
     companion object {
         /**

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsMiddleware.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsMiddleware.kt
@@ -4,9 +4,12 @@ import io.ethers.core.success
 import io.ethers.core.types.BlockId
 import io.ethers.core.types.BlockOverride
 import io.ethers.core.types.Bytes
+import io.ethers.core.types.CreateAccessList
 import io.ethers.core.types.Hash
 import io.ethers.core.types.IntoCallRequest
 import io.ethers.core.types.StateOverride
+import io.ethers.core.types.tracers.TracerConfig
+import io.ethers.core.types.transaction.TransactionUnsigned
 import io.ethers.providers.RpcError
 import io.ethers.providers.middleware.Middleware
 import io.ethers.providers.types.RpcRequest
@@ -26,6 +29,9 @@ import io.ethers.providers.types.SuppliedRpcRequest
  * Note that [Middleware] fixes the error type of these methods to [RpcError], so ENS failures are wrapped in an
  * [RpcError] with code [CODE_ENS_RESOLUTION_FAILED] and the typed [EnsResolver.Error] as their cause. Use [ens]
  * directly when you need the typed error.
+ *
+ * Note that [callMany] does not resolve ENS names: it takes a list of call requests, and resolving each element
+ * is not yet supported. Resolve the names up front with [ens] and pass plain call requests instead.
  * */
 class EnsMiddleware(
     override val inner: Middleware,
@@ -106,6 +112,57 @@ class EnsMiddleware(
         stateOverride: StateOverride?,
         blockOverride: BlockOverride?,
     ) = call(call, BlockId.Number(blockNumber), stateOverride, blockOverride)
+
+    //-----------------------------------------------------------------------------------------------------------------
+    //                                  Remaining IntoCallRequest-shaped methods
+    //-----------------------------------------------------------------------------------------------------------------
+    override fun estimateGas(call: IntoCallRequest, blockId: BlockId): RpcRequest<Long, RpcError> {
+        if (call !is EnsCallRequest) {
+            return inner.estimateGas(call, blockId)
+        }
+
+        return resolveRecipient(call).andThen { resolved -> inner.estimateGas(resolved, blockId).send() }
+    }
+
+    override fun estimateGas(call: IntoCallRequest, hash: Hash) = estimateGas(call, BlockId.Hash(hash))
+
+    override fun estimateGas(call: IntoCallRequest, number: Long) = estimateGas(call, BlockId.Number(number))
+
+    override fun createAccessList(call: IntoCallRequest, blockId: BlockId): RpcRequest<CreateAccessList, RpcError> {
+        if (call !is EnsCallRequest) {
+            return inner.createAccessList(call, blockId)
+        }
+
+        return resolveRecipient(call).andThen { resolved -> inner.createAccessList(resolved, blockId).send() }
+    }
+
+    override fun createAccessList(call: IntoCallRequest, hash: Hash) = createAccessList(call, BlockId.Hash(hash))
+
+    override fun createAccessList(call: IntoCallRequest, number: Long) = createAccessList(call, BlockId.Number(number))
+
+    override fun fillTransaction(call: IntoCallRequest): RpcRequest<TransactionUnsigned, RpcError> {
+        if (call !is EnsCallRequest) {
+            return inner.fillTransaction(call)
+        }
+
+        return resolveRecipient(call).andThen { resolved -> inner.fillTransaction(resolved).send() }
+    }
+
+    override fun <T : Any> traceCall(
+        call: IntoCallRequest,
+        blockId: BlockId,
+        config: TracerConfig<T>,
+    ): RpcRequest<T, RpcError> {
+        if (call !is EnsCallRequest) {
+            return inner.traceCall(call, blockId, config)
+        }
+
+        return resolveRecipient(call).andThen { resolved -> inner.traceCall(resolved, blockId, config).send() }
+    }
+
+    override fun <T : Any> traceCall(call: IntoCallRequest, blockNumber: Long, config: TracerConfig<T>) = traceCall(call, BlockId.Number(blockNumber), config)
+
+    override fun <T : Any> traceCall(call: IntoCallRequest, blockHash: Hash, config: TracerConfig<T>) = traceCall(call, BlockId.Hash(blockHash), config)
 
     companion object {
         /**

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsMiddleware.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsMiddleware.kt
@@ -1,0 +1,116 @@
+package io.ethers.ens
+
+import io.ethers.core.success
+import io.ethers.core.types.BlockId
+import io.ethers.core.types.BlockOverride
+import io.ethers.core.types.Bytes
+import io.ethers.core.types.Hash
+import io.ethers.core.types.IntoCallRequest
+import io.ethers.core.types.StateOverride
+import io.ethers.providers.RpcError
+import io.ethers.providers.middleware.Middleware
+import io.ethers.providers.types.RpcRequest
+import io.ethers.providers.types.SuppliedRpcRequest
+
+/**
+ * A [Middleware] layer that accepts an [EnsCallRequest] anywhere a call request is expected, resolves its ENS
+ * name to an [io.ethers.core.types.Address], and forwards a plain call request to [inner].
+ *
+ * ```kotlin
+ * val provider = EnsMiddleware(Provider.builder(url).buildAwait().unwrap())
+ * provider.call(EnsCallRequest("vitalik.eth").data(callData), BlockId.LATEST).sendAwait()
+ * ```
+ *
+ * Requests that are not an [EnsCallRequest] are passed through untouched, at no extra cost.
+ *
+ * Note that [Middleware] fixes the error type of these methods to [RpcError], so ENS failures are wrapped in an
+ * [RpcError] with code [CODE_ENS_RESOLUTION_FAILED] and the typed [EnsResolver.Error] as their cause. Use [ens]
+ * directly when you need the typed error.
+ * */
+class EnsMiddleware(
+    override val inner: Middleware,
+    val ens: EnsResolver,
+) : Middleware by inner {
+    constructor(inner: Middleware) : this(inner, EnsResolver(inner))
+
+    /**
+     * Resolve [call]'s recipient if it is an [EnsCallRequest], otherwise return it unchanged.
+     * */
+    internal fun resolveRecipient(call: IntoCallRequest): RpcRequest<IntoCallRequest, RpcError> {
+        if (call !is EnsCallRequest) {
+            return SuppliedRpcRequest { success(call) }
+        }
+
+        return ens.resolveAddress(call.toEnsName)
+            .mapError { error ->
+                RpcError(
+                    CODE_ENS_RESOLUTION_FAILED,
+                    "Failed to resolve ENS name '${call.toEnsName}': ${error.message}",
+                    null,
+                    error.toException(),
+                )
+            }
+            .map { address -> call.resolveTo(address) }
+    }
+
+    //-----------------------------------------------------------------------------------------------------------------
+    //                                  EthApi#call
+    //
+    // IMPORTANT: Kotlin class delegation generates a forwarder to `inner` for every interface member this class
+    // does not override, including members that have a default body. The convenience overloads below therefore
+    // have to be overridden too - otherwise they would call `inner` directly and skip name resolution entirely.
+    //-----------------------------------------------------------------------------------------------------------------
+    override fun call(
+        call: IntoCallRequest,
+        blockId: BlockId,
+        stateOverride: StateOverride?,
+        blockOverride: BlockOverride?,
+    ): RpcRequest<Bytes, RpcError> {
+        if (call !is EnsCallRequest) {
+            return inner.call(call, blockId, stateOverride, blockOverride)
+        }
+
+        return resolveRecipient(call).andThen { resolved ->
+            inner.call(resolved, blockId, stateOverride, blockOverride).send()
+        }
+    }
+
+    override fun call(call: IntoCallRequest, blockId: BlockId) = call(call, blockId, null, null)
+
+    override fun call(call: IntoCallRequest, blockHash: Hash) = call(call, BlockId.Hash(blockHash), null, null)
+
+    override fun call(call: IntoCallRequest, blockNumber: Long) = call(call, BlockId.Number(blockNumber), null, null)
+
+    override fun call(call: IntoCallRequest, blockId: BlockId, stateOverride: StateOverride) = call(call, blockId, stateOverride, null)
+
+    override fun call(call: IntoCallRequest, blockHash: Hash, stateOverride: StateOverride) = call(call, BlockId.Hash(blockHash), stateOverride, null)
+
+    override fun call(call: IntoCallRequest, blockNumber: Long, stateOverride: StateOverride) = call(call, BlockId.Number(blockNumber), stateOverride, null)
+
+    override fun call(call: IntoCallRequest, blockId: BlockId, blockOverride: BlockOverride) = call(call, blockId, null, blockOverride)
+
+    override fun call(call: IntoCallRequest, blockHash: Hash, blockOverride: BlockOverride) = call(call, BlockId.Hash(blockHash), null, blockOverride)
+
+    override fun call(call: IntoCallRequest, blockNumber: Long, blockOverride: BlockOverride) = call(call, BlockId.Number(blockNumber), null, blockOverride)
+
+    override fun call(
+        call: IntoCallRequest,
+        blockHash: Hash,
+        stateOverride: StateOverride?,
+        blockOverride: BlockOverride?,
+    ) = call(call, BlockId.Hash(blockHash), stateOverride, blockOverride)
+
+    override fun call(
+        call: IntoCallRequest,
+        blockNumber: Long,
+        stateOverride: StateOverride?,
+        blockOverride: BlockOverride?,
+    ) = call(call, BlockId.Number(blockNumber), stateOverride, blockOverride)
+
+    companion object {
+        /**
+         * [RpcError.code] used when an RPC call failed because its ENS name could not be resolved.
+         * */
+        const val CODE_ENS_RESOLUTION_FAILED = 5100
+    }
+}

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsMiddleware.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsMiddleware.kt
@@ -54,11 +54,11 @@ class EnsMiddleware(
             return SuppliedRpcRequest { success(call) }
         }
 
-        return ens.resolveAddress(call.toEnsName)
+        return ens.resolveAddress(call.toEns)
             .mapError { error ->
                 RpcError(
                     CODE_ENS_RESOLUTION_FAILED,
-                    "Failed to resolve ENS name '${call.toEnsName}': ${error.message}",
+                    "Failed to resolve ENS name '${call.toEns}': ${error.message}",
                     null,
                     error.toException(),
                 )

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsNameCache.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsNameCache.kt
@@ -1,0 +1,49 @@
+package io.ethers.ens
+
+import io.ethers.core.types.Address
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+
+/**
+ * A TTL cache of ENS name to [Address] resolutions.
+ *
+ * Resolving one name costs multiple round trips (registry lookup, interface probes, and the resolution itself),
+ * while ENS records change rarely, so caching for a short window removes almost all of that traffic.
+ * */
+class EnsNameCache(
+    private val ttl: Duration = 5.minutes,
+    private val timeSource: TimeSource = TimeSource.Monotonic,
+) {
+    private val lock = SynchronizedObject()
+    private val entries = HashMap<String, Entry>()
+
+    private class Entry(val address: Address, val resolvedAt: TimeMark)
+
+    /**
+     * Get the cached address for [name], or null if it was never cached or its ttl has elapsed.
+     * */
+    fun get(name: String): Address? = synchronized(lock) {
+        val entry = entries[name] ?: return null
+        if (entry.resolvedAt.elapsedNow() >= ttl) {
+            entries.remove(name)
+            return null
+        }
+        entry.address
+    }
+
+    /**
+     * Cache [address] as the resolution of [name].
+     * */
+    fun put(name: String, address: Address): Unit = synchronized(lock) {
+        entries[name] = Entry(address, timeSource.markNow())
+    }
+
+    /**
+     * Drop every cached entry.
+     * */
+    fun clear(): Unit = synchronized(lock) { entries.clear() }
+}

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsResolver.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsResolver.kt
@@ -17,7 +17,7 @@ import io.ethers.core.types.BlockId
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.CallRequest
 import io.ethers.core.unwrapOrReturn
-import io.ethers.ens.EnsMiddleware.Companion.IPFS_GATEWAY
+import io.ethers.ens.EnsResolver.Companion.IPFS_GATEWAY
 import io.ethers.logger.err
 import io.ethers.logger.getLogger
 import io.ethers.logger.wrn
@@ -39,12 +39,12 @@ import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmOverloads
 import io.ktor.client.HttpClient as KtorHttpClient
 
-class EnsMiddleware @JvmOverloads constructor(
-    provider: Middleware,
+class EnsResolver @JvmOverloads constructor(
+    val provider: Middleware,
     private val registryAddress: Address,
     private val ccipLookupLimit: Int = 4,
     private val httpClient: KtorHttpClient = RpcClientConfig().client!!,
-) : Middleware by provider {
+) {
     private val LOG = getLogger()
     private val registryContract = EnsRegistry(provider, registryAddress)
 
@@ -173,7 +173,7 @@ class EnsMiddleware @JvmOverloads constructor(
             return failure(Error.Normalisation(it))
         }
 
-        val resolverResponse = getResolver(ensName)
+        val resolverResponse = getOnchainResolver(ensName)
         if (resolverResponse.isFailure()) return resolverResponse
 
         // Unwrap resolver from RpcResponse and call its addr() function.
@@ -272,14 +272,14 @@ class EnsMiddleware @JvmOverloads constructor(
     /**
      * Get [ExtendedResolver] for [ensName] using [EnsRegistry] of current chain.
      */
-    private suspend fun getResolver(ensName: String): Result<ExtendedResolver, Error> {
-        return getResolverAddress(ensName).map { ExtendedResolver(provider, it) }
+    private suspend fun getOnchainResolver(ensName: String): Result<ExtendedResolver, Error> {
+        return getOnchainResolverAddress(ensName).map { ExtendedResolver(provider, it) }
     }
 
     /**
      * Get resolver address for [ensName] from [EnsRegistry].
      */
-    private suspend fun getResolverAddress(ensName: String): Result<Address, Error> {
+    private suspend fun getOnchainResolverAddress(ensName: String): Result<Address, Error> {
         if (ensName.isEmpty()) {
             return failure(Error.UnknownResolver)
         }
@@ -299,7 +299,7 @@ class EnsMiddleware @JvmOverloads constructor(
             .send()
 
         if (address.unwrapErrorOrNull()?.asTypeOrNull<Error.UnknownResolver>() != null) {
-            return getResolverAddress(getParent(ensName))
+            return getOnchainResolverAddress(getParent(ensName))
         }
 
         return address
@@ -475,8 +475,8 @@ class EnsMiddleware @JvmOverloads constructor(
         val nftToken = parseResult.unwrap()
 
         // Validate that the NFT is on the same chain as the provider
-        if (nftToken.chainId != chainId) {
-            return failure(Error.AvatarChainIdMismatch(nftToken.chainId, chainId, avatarUri))
+        if (nftToken.chainId != provider.chainId) {
+            return failure(Error.AvatarChainIdMismatch(nftToken.chainId, provider.chainId, avatarUri))
         }
 
         // validate NFT ownership
@@ -614,7 +614,7 @@ class EnsMiddleware @JvmOverloads constructor(
         val reverseAddr = reverseAddressEnsName(address)
 
         // Get resolver for reverse address ENS
-        val resolverResponse = getResolver(reverseAddr)
+        val resolverResponse = getOnchainResolver(reverseAddr)
         if (resolverResponse.isFailure()) return resolverResponse
         val reverseResolver = resolverResponse.unwrap()
 
@@ -707,7 +707,7 @@ class EnsMiddleware @JvmOverloads constructor(
         }
 
         /**
-         * Resolver address not found for given nameHash on registry.
+         * No on-chain ENS resolver contract is registered for the given nameHash in the registry.
          */
         data object UnknownResolver : Error()
 

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsResolver.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsResolver.kt
@@ -16,6 +16,7 @@ import io.ethers.core.types.Address
 import io.ethers.core.types.BlockId
 import io.ethers.core.types.Bytes
 import io.ethers.core.types.CallRequest
+import io.ethers.core.types.Hash
 import io.ethers.core.unwrapOrReturn
 import io.ethers.ens.EnsResolver.Companion.IPFS_GATEWAY
 import io.ethers.logger.err
@@ -152,6 +153,39 @@ class EnsResolver @JvmOverloads constructor(
         if (uriRes.isFailure()) return uriRes
 
         return matchAvatarUri(uriRes.unwrap(), address)
+    }
+
+    /**
+     * Get the balance of the account [ensName] resolves to, at [blockId].
+     * */
+    fun getBalance(ensName: String, blockId: BlockId): RpcRequest<BigInteger, Error> = SuppliedRpcRequest {
+        val address = resolveAddressInternal(ensName).unwrapOrReturn { return@SuppliedRpcRequest failure(it) }
+        provider.getBalance(address, blockId).send().mapError { Error.RpcCallFailed("eth_getBalance", it) }
+    }
+
+    /**
+     * Get the deployed code of the account [ensName] resolves to, at [blockId].
+     * */
+    fun getCode(ensName: String, blockId: BlockId): RpcRequest<Bytes, Error> = SuppliedRpcRequest {
+        val address = resolveAddressInternal(ensName).unwrapOrReturn { return@SuppliedRpcRequest failure(it) }
+        provider.getCode(address, blockId).send().mapError { Error.RpcCallFailed("eth_getCode", it) }
+    }
+
+    /**
+     * Get the transaction count of the account [ensName] resolves to, at [blockId].
+     * */
+    fun getTransactionCount(ensName: String, blockId: BlockId): RpcRequest<Long, Error> = SuppliedRpcRequest {
+        val address = resolveAddressInternal(ensName).unwrapOrReturn { return@SuppliedRpcRequest failure(it) }
+        provider.getTransactionCount(address, blockId).send()
+            .mapError { Error.RpcCallFailed("eth_getTransactionCount", it) }
+    }
+
+    /**
+     * Get the storage value at [key] of the account [ensName] resolves to, at [blockId].
+     * */
+    fun getStorage(ensName: String, key: Hash, blockId: BlockId): RpcRequest<Hash, Error> = SuppliedRpcRequest {
+        val address = resolveAddressInternal(ensName).unwrapOrReturn { return@SuppliedRpcRequest failure(it) }
+        provider.getStorage(address, key, blockId).send().mapError { Error.RpcCallFailed("eth_getStorage", it) }
     }
 
     /**
@@ -751,6 +785,17 @@ class EnsResolver @JvmOverloads constructor(
          * The owner of ENS name is incorrect
          */
         data class IncorrectOwner(override val message: String) : Error()
+
+        /**
+         * The ENS name resolved successfully, but the RPC call made against the resolved address failed.
+         */
+        data class RpcCallFailed(
+            val method: String,
+            val error: RpcError,
+        ) : Error() {
+            override val message get() = "RPC call '$method' failed after resolving the ENS name"
+            override val cause get() = error.toException()
+        }
 
         // Avatar specific errors
 

--- a/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsResolver.kt
+++ b/ethers-ens/src/commonMain/kotlin/io/ethers/ens/EnsResolver.kt
@@ -45,6 +45,7 @@ class EnsResolver @JvmOverloads constructor(
     private val registryAddress: Address,
     private val ccipLookupLimit: Int = 4,
     private val httpClient: KtorHttpClient = RpcClientConfig().client!!,
+    private val cache: EnsNameCache = EnsNameCache(),
 ) {
     private val LOG = getLogger()
     private val registryContract = EnsRegistry(provider, registryAddress)
@@ -54,11 +55,13 @@ class EnsResolver @JvmOverloads constructor(
         provider: Middleware,
         ccipLookupLimit: Int = 4,
         client: KtorHttpClient = RpcClientConfig().client!!,
+        cache: EnsNameCache = EnsNameCache(),
     ) : this(
         provider,
         getRegistryAddressOrThrow(provider.chainId),
         ccipLookupLimit,
         client,
+        cache,
     )
 
     /**
@@ -73,10 +76,16 @@ class EnsResolver @JvmOverloads constructor(
     }
 
     private suspend fun resolveAddressInternal(ensName: String): Result<Address, Error> {
+        cache.get(ensName)?.let { return success(it) }
+
         return resolveWithParameters(
             ensName,
             ExtendedResolver.FUNCTION_ADDR,
         ).map { AbiCodec.decode(AbiType.Address, it.asByteArray()) }
+            .andThen { address ->
+                cache.put(ensName, address)
+                success(address)
+            }
     }
 
     /**

--- a/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsCallRequestTest.kt
+++ b/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsCallRequestTest.kt
@@ -92,13 +92,24 @@ class EnsCallRequestTest : FunSpec({
             .gas(21000L)
             .toEns("vitalik.eth")
 
-        call.toEnsName shouldBe "vitalik.eth"
+        call.toEns shouldBe "vitalik.eth"
 
         val resolvedCall = call.resolveTo(resolved)
         resolvedCall.to shouldBe resolved
         resolvedCall.from shouldBe from
         resolvedCall.data shouldBe Bytes("0x1234")
         resolvedCall.gas shouldBe 21000L
+    }
+
+    test("resolveTo copies, so the builder lambda's request is not aliased into the dispatched call") {
+        val call = EnsCallRequest("vitalik.eth") { data = Bytes("0x1234") }
+        val first = Address("0x0000000000000000000000000000000000000001")
+
+        val resolved = call.resolveTo(first)
+        resolved.data = Bytes("0xffff")
+
+        // mutating a resolved request must not reach back into the EnsCallRequest
+        call.resolveTo(first).data shouldBe Bytes("0x1234")
     }
 
     test("toEns copies, so mutating the source afterwards does not leak into the wrapper") {

--- a/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsCallRequestTest.kt
+++ b/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsCallRequestTest.kt
@@ -1,0 +1,112 @@
+package io.ethers.ens
+
+import io.ethers.core.types.Address
+import io.ethers.core.types.Bytes
+import io.ethers.core.types.CallRequest
+import io.github.artificialpb.bignum.bigIntegerOf
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class EnsCallRequestTest : FunSpec({
+    test("toCallRequest throws instead of silently producing a request with no recipient") {
+        val request = EnsCallRequest("vitalik.eth", CallRequest().data(Bytes("0x1234")))
+
+        val thrown = shouldThrow<IllegalStateException> { request.toCallRequest() }
+
+        thrown.message shouldContain "vitalik.eth"
+        thrown.message shouldContain "EnsMiddleware"
+    }
+
+    test("resolveTo carries every other field over onto the resolved address") {
+        val resolved = Address("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+        val from = Address("0x0000000000000000000000000000000000000001")
+        val request = EnsCallRequest(
+            "vitalik.eth",
+            CallRequest().from(from).data(Bytes("0x1234")).value(bigIntegerOf(7)).gas(21000L),
+        )
+
+        val call = request.resolveTo(resolved)
+
+        call.to shouldBe resolved
+        call.from shouldBe from
+        call.data shouldBe Bytes("0x1234")
+        call.value shouldBe bigIntegerOf(7)
+        call.gas shouldBe 21000L
+    }
+
+    test("resolveTo does not mutate the request, so it can be resolved more than once") {
+        val base = CallRequest().data(Bytes("0x1234"))
+        val request = EnsCallRequest("vitalik.eth", base)
+        val first = Address("0x0000000000000000000000000000000000000001")
+        val second = Address("0x0000000000000000000000000000000000000002")
+
+        request.resolveTo(first).to shouldBe first
+        request.resolveTo(second).to shouldBe second
+        base.to shouldBe null
+    }
+
+    test("chaining builders configure the underlying request and return EnsCallRequest") {
+        val resolved = Address("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+        val from = Address("0x0000000000000000000000000000000000000001")
+
+        val call = EnsCallRequest("vitalik.eth")
+            .from(from)
+            .data(Bytes("0x1234"))
+            .value(bigIntegerOf(7))
+            .gas(21000L)
+            .nonce(3L)
+            .chainId(1L)
+            .resolveTo(resolved)
+
+        call.to shouldBe resolved
+        call.from shouldBe from
+        call.data shouldBe Bytes("0x1234")
+        call.value shouldBe bigIntegerOf(7)
+        call.gas shouldBe 21000L
+        call.nonce shouldBe 3L
+        call.chainId shouldBe 1L
+    }
+
+    test("the builder lambda overload configures via CallRequest's own property setters") {
+        val resolved = Address("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+
+        val call = EnsCallRequest("vitalik.eth") {
+            data = Bytes("0x1234")
+            value = bigIntegerOf(7)
+        }.resolveTo(resolved)
+
+        call.to shouldBe resolved
+        call.data shouldBe Bytes("0x1234")
+        call.value shouldBe bigIntegerOf(7)
+    }
+
+    test("toEns wraps an existing CallRequest, keeping every field") {
+        val resolved = Address("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+        val from = Address("0x0000000000000000000000000000000000000001")
+
+        val call = CallRequest()
+            .from(from)
+            .data(Bytes("0x1234"))
+            .gas(21000L)
+            .toEns("vitalik.eth")
+
+        call.toEnsName shouldBe "vitalik.eth"
+
+        val resolvedCall = call.resolveTo(resolved)
+        resolvedCall.to shouldBe resolved
+        resolvedCall.from shouldBe from
+        resolvedCall.data shouldBe Bytes("0x1234")
+        resolvedCall.gas shouldBe 21000L
+    }
+
+    test("toEns copies, so mutating the source afterwards does not leak into the wrapper") {
+        val source = CallRequest().data(Bytes("0x1234"))
+        val call = source.toEns("vitalik.eth")
+
+        source.data = Bytes("0xffff")
+
+        call.resolveTo(Address.ZERO).data shouldBe Bytes("0x1234")
+    }
+})

--- a/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsErrorTest.kt
+++ b/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsErrorTest.kt
@@ -14,7 +14,7 @@ class EnsErrorTest : FunSpec({
     context("errors carrying a structured cause") {
         test("CcipCallbackFailed keeps the RpcError and chains its exception") {
             val rpcError = RpcError(-32000, "execution reverted", null)
-            val error = EnsMiddleware.Error.CcipCallbackFailed(rpcError)
+            val error = EnsResolver.Error.CcipCallbackFailed(rpcError)
 
             // the cause stays a fully typed RpcError, not a flattened exception
             error.error shouldBe rpcError
@@ -28,7 +28,7 @@ class EnsErrorTest : FunSpec({
 
         test("AvatarNftCallFailed keeps the ContractError and chains its exception") {
             val decodingError = DecodingError(Bytes("0x1234"), "failed to decode tokenURI", null)
-            val error = EnsMiddleware.Error.AvatarNftCallFailed("Error when retrieving metadata URL", decodingError)
+            val error = EnsResolver.Error.AvatarNftCallFailed("Error when retrieving metadata URL", decodingError)
 
             // the cause stays a fully typed ContractError, not a flattened exception
             error.error shouldBe decodingError
@@ -43,7 +43,7 @@ class EnsErrorTest : FunSpec({
     context("errors carrying a plain throwable cause") {
         test("Normalisation keeps the original throwable and chains it") {
             val cause = IllegalArgumentException("invalid label")
-            val error = EnsMiddleware.Error.Normalisation(cause)
+            val error = EnsResolver.Error.Normalisation(cause)
 
             error.cause shouldBe cause
 
@@ -53,7 +53,7 @@ class EnsErrorTest : FunSpec({
         }
 
         test("AvatarParsing chains a null cause without failing") {
-            val error = EnsMiddleware.Error.AvatarParsing("Unsupported URI link", null)
+            val error = EnsResolver.Error.AvatarParsing("Unsupported URI link", null)
 
             val exception = error.toException()
             exception.message shouldBe "Unsupported URI link"
@@ -63,7 +63,7 @@ class EnsErrorTest : FunSpec({
 
     context("the thrown exception stays typed") {
         test("the original error is recoverable from a catch block") {
-            val error = EnsMiddleware.Error.UnknownEnsName(
+            val error = EnsResolver.Error.UnknownEnsName(
                 Address("0x0000000000000000000000000000000000000001"),
                 "0xabcd",
             )
@@ -74,7 +74,7 @@ class EnsErrorTest : FunSpec({
                 e
             }
 
-            caught.error.asTypeOrNull<EnsMiddleware.Error.UnknownEnsName>()?.nameHash shouldBe "0xabcd"
+            caught.error.asTypeOrNull<EnsResolver.Error.UnknownEnsName>()?.nameHash shouldBe "0xabcd"
         }
     }
 })

--- a/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsMiddlewareBatchTest.kt
+++ b/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsMiddlewareBatchTest.kt
@@ -1,0 +1,141 @@
+package io.ethers.ens
+
+import io.channels.core.ChannelReceiver
+import io.ethers.core.Result
+import io.ethers.core.isFailure
+import io.ethers.core.types.Address
+import io.ethers.core.types.BlockId
+import io.ethers.core.types.Bytes
+import io.ethers.core.types.CallRequest
+import io.ethers.providers.JsonRpcClient
+import io.ethers.providers.Provider
+import io.ethers.providers.RpcError
+import io.ethers.providers.types.BatchRpcRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.yield
+import kotlinx.serialization.json.JsonElement as KJsonElement
+
+private val RESOLVER = Address("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63")
+private val VITALIK = Address("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+private val NICK = Address("0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5")
+
+/**
+ * Wraps a [FakeJsonRpcClient] and records how many requests were in flight at once.
+ *
+ * Each request yields before delegating, so any coroutine that has already started gets a chance to enter the
+ * request before the first one completes. Sequential resolution therefore peaks at 1, concurrent at N.
+ */
+private class ConcurrencyTrackingClient(private val delegate: FakeJsonRpcClient) : JsonRpcClient {
+    private var inFlight = 0
+    var maxInFlight = 0
+        private set
+
+    override suspend fun <T> request(
+        method: String,
+        params: Array<*>,
+        resultDecoder: (KJsonElement) -> T,
+    ): Result<T, RpcError> {
+        inFlight++
+        maxInFlight = maxOf(maxInFlight, inFlight)
+        yield()
+        val result = delegate.request(method, params, resultDecoder)
+        inFlight--
+        return result
+    }
+
+    override suspend fun requestBatch(batch: BatchRpcRequest) = delegate.requestBatch(batch)
+
+    override suspend fun <T : Any> subscribe(
+        params: Array<*>,
+        resultDecoder: (KJsonElement) -> T,
+    ): Result<ChannelReceiver<T>, RpcError> = delegate.subscribe(params, resultDecoder)
+
+    override fun close() = delegate.close()
+}
+
+class EnsMiddlewareBatchTest : FunSpec({
+    test("callMany resolves every ENS name and dispatches the resolved addresses") {
+        val plainTo = Address("0x0000000000000000000000000000000000000001")
+        val client = FakeJsonRpcClient()
+            .serveEnsNames(RESOLVER, "vitalik.eth" to VITALIK, "nick.eth" to NICK)
+            .enqueue("eth_callMany", """[{"value":"0xaa"},{"value":"0xbb"},{"value":"0xcc"}]""")
+        val middleware = EnsMiddleware(Provider(client, 1L))
+
+        val result = middleware.callMany(
+            BlockId.LATEST,
+            listOf(
+                EnsCallRequest("vitalik.eth").data(Bytes("0x1234")),
+                CallRequest().to(plainTo),
+                EnsCallRequest("nick.eth"),
+            ),
+        ).send()
+
+        result.unwrap().size shouldBe 3
+
+        // the bundle keeps input order, with only the ENS entries rewritten
+        val bundle = client.requests.last().params[0].toString()
+        bundle shouldContain VITALIK.toString()
+        bundle shouldContain plainTo.toString()
+        bundle shouldContain NICK.toString()
+    }
+
+    test("names in a batch resolve concurrently rather than one after another") {
+        val fake = FakeJsonRpcClient()
+            .serveEnsNames(RESOLVER, "vitalik.eth" to VITALIK, "nick.eth" to NICK)
+            .enqueue("eth_callMany", """[{"value":"0xaa"},{"value":"0xbb"}]""")
+        val client = ConcurrencyTrackingClient(fake)
+        val middleware = EnsMiddleware(Provider(client, 1L))
+
+        middleware.callMany(
+            BlockId.LATEST,
+            listOf(EnsCallRequest("vitalik.eth"), EnsCallRequest("nick.eth")),
+        ).send().unwrap()
+
+        // sequential resolution would never have more than one request in flight
+        client.maxInFlight shouldBe 2
+    }
+
+    test("a batch with no ENS names passes through without any resolution traffic") {
+        val to = Address("0x0000000000000000000000000000000000000001")
+        val client = FakeJsonRpcClient().enqueue("eth_callMany", """[{"value":"0xaa"}]""")
+        val middleware = EnsMiddleware(Provider(client, 1L))
+
+        middleware.callMany(BlockId.LATEST, listOf(CallRequest().to(to))).send().unwrap()
+
+        client.requests.size shouldBe 1
+        client.requests[0].method shouldBe "eth_callMany"
+    }
+
+    test("one unresolvable name fails the whole batch") {
+        // nonexistent.eth is not registered, so the registry reports no resolver for it or its parent
+        val client = FakeJsonRpcClient()
+            .serveEnsNames(RESOLVER, "vitalik.eth" to VITALIK)
+        val middleware = EnsMiddleware(Provider(client, 1L))
+
+        val result = middleware.callMany(
+            BlockId.LATEST,
+            listOf(EnsCallRequest("vitalik.eth"), EnsCallRequest("nonexistent.eth")),
+        ).send()
+
+        result.isFailure() shouldBe true
+        result.unwrapError().code shouldBe EnsMiddleware.CODE_ENS_RESOLUTION_FAILED
+        result.unwrapError().message shouldContain "nonexistent.eth"
+
+        // the batch itself was never dispatched
+        client.requests.none { it.method == "eth_callMany" } shouldBe true
+    }
+
+    // regression test: same delegation trap as the single-call overloads
+    test("the block-number callMany overload also resolves names") {
+        val client = FakeJsonRpcClient()
+            .serveEnsNames(RESOLVER, "vitalik.eth" to VITALIK)
+            .enqueue("eth_callMany", """[{"value":"0xaa"}]""")
+        val middleware = EnsMiddleware(Provider(client, 1L))
+
+        middleware.callMany(1L, listOf(EnsCallRequest("vitalik.eth"))).send().unwrap()
+
+        client.requests.last().params[0].toString() shouldContain VITALIK.toString()
+    }
+})

--- a/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsMiddlewareTest.kt
+++ b/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsMiddlewareTest.kt
@@ -70,6 +70,29 @@ class EnsMiddlewareTest : FunSpec({
         error.cause.shouldNotBeNull()
     }
 
+    test("estimateGas resolves the ENS name") {
+        val client = FakeJsonRpcClient()
+            .enqueueAddressResolution(RESOLVER, VITALIK)
+            .enqueue("eth_estimateGas", "\"0x5208\"")
+        val middleware = EnsMiddleware(Provider(client, 1L))
+
+        val result = middleware.estimateGas(EnsCallRequest("vitalik.eth"), BlockId.LATEST).send()
+
+        result.unwrap() shouldBe 21000L
+        (client.requests.last().params[0] as CallRequest).to shouldBe VITALIK
+    }
+
+    test("createAccessList resolves the ENS name") {
+        val client = FakeJsonRpcClient()
+            .enqueueAddressResolution(RESOLVER, VITALIK)
+            .enqueue("eth_createAccessList", """{"accessList":[],"gasUsed":"0x5208"}""")
+        val middleware = EnsMiddleware(Provider(client, 1L))
+
+        middleware.createAccessList(EnsCallRequest("vitalik.eth"), BlockId.LATEST).send().unwrap()
+
+        (client.requests.last().params[0] as CallRequest).to shouldBe VITALIK
+    }
+
     test("inner points at the wrapped middleware instead of reporting itself as the bottom layer") {
         val provider = Provider(FakeJsonRpcClient(), 1L)
         val middleware = EnsMiddleware(provider)

--- a/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsMiddlewareTest.kt
+++ b/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsMiddlewareTest.kt
@@ -1,0 +1,80 @@
+package io.ethers.ens
+
+import io.ethers.core.isFailure
+import io.ethers.core.types.Address
+import io.ethers.core.types.BlockId
+import io.ethers.core.types.Bytes
+import io.ethers.core.types.CallRequest
+import io.ethers.providers.Provider
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+private val RESOLVER = Address("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63")
+private val VITALIK = Address("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+
+class EnsMiddlewareTest : FunSpec({
+    test("resolves the ENS name and dispatches the call to the resolved address") {
+        val client = FakeJsonRpcClient()
+            .enqueueAddressResolution(RESOLVER, VITALIK)
+            .enqueue("eth_call", "\"0xdeadbeef\"")
+        val middleware = EnsMiddleware(Provider(client, 1L))
+
+        val result = middleware
+            .call(EnsCallRequest("vitalik.eth", CallRequest().data(Bytes("0x1234"))), BlockId.LATEST, null, null)
+            .send()
+
+        result.unwrap() shouldBe Bytes("0xdeadbeef")
+        val dispatched = client.requests.last().params[0] as CallRequest
+        dispatched.to shouldBe VITALIK
+        dispatched.data shouldBe Bytes("0x1234")
+    }
+
+    // regression test: Kotlin class delegation generates forwarders for interface members that have default
+    // bodies, so the convenience overloads would otherwise bypass the override above and hit `inner` directly
+    test("the two-argument call overload also resolves the name") {
+        val client = FakeJsonRpcClient()
+            .enqueueAddressResolution(RESOLVER, VITALIK)
+            .enqueue("eth_call", "\"0xdeadbeef\"")
+        val middleware = EnsMiddleware(Provider(client, 1L))
+
+        val result = middleware.call(EnsCallRequest("vitalik.eth"), BlockId.LATEST).send()
+
+        result.unwrap() shouldBe Bytes("0xdeadbeef")
+        (client.requests.last().params[0] as CallRequest).to shouldBe VITALIK
+    }
+
+    test("a plain CallRequest passes straight through without any resolution traffic") {
+        val to = Address("0x0000000000000000000000000000000000000001")
+        val client = FakeJsonRpcClient().enqueue("eth_call", "\"0xdeadbeef\"")
+        val middleware = EnsMiddleware(Provider(client, 1L))
+
+        middleware.call(CallRequest().to(to), BlockId.LATEST).send().unwrap() shouldBe Bytes("0xdeadbeef")
+
+        client.requests.size shouldBe 1
+        (client.requests[0].params[0] as CallRequest).to shouldBe to
+    }
+
+    test("a resolution failure surfaces as an RpcError that keeps the ENS error as its cause") {
+        // registry returns the zero address, so no resolver is registered for the name
+        val client = FakeJsonRpcClient().enqueue("eth_call", "\"${abiWord(Address.ZERO)}\"")
+        val middleware = EnsMiddleware(Provider(client, 1L))
+
+        val result = middleware.call(EnsCallRequest("nonexistent.eth"), BlockId.LATEST).send()
+
+        result.isFailure() shouldBe true
+        val error = result.unwrapError()
+        error.code shouldBe EnsMiddleware.CODE_ENS_RESOLUTION_FAILED
+        error.message shouldContain "nonexistent.eth"
+        error.cause.shouldNotBeNull()
+    }
+
+    test("inner points at the wrapped middleware instead of reporting itself as the bottom layer") {
+        val provider = Provider(FakeJsonRpcClient(), 1L)
+        val middleware = EnsMiddleware(provider)
+
+        middleware.inner shouldBe provider
+        middleware.provider shouldBe provider
+    }
+})

--- a/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsNameCacheTest.kt
+++ b/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsNameCacheTest.kt
@@ -1,0 +1,54 @@
+package io.ethers.ens
+
+import io.ethers.core.types.Address
+import io.ethers.providers.Provider
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.ExperimentalTime
+import kotlin.time.TestTimeSource
+
+private val RESOLVER = Address("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63")
+private val VITALIK = Address("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+
+// TestTimeSource has carried @ExperimentalTime across Kotlin versions and the test tasks only opt into
+// RequiresOptIn/ExperimentalStdlibApi/ExperimentalKotest. Opting in explicitly compiles either way - if the
+// marker is no longer required this is only a warning, and the build does not set allWarningsAsErrors.
+@OptIn(ExperimentalTime::class)
+class EnsNameCacheTest : FunSpec({
+    test("returns a cached entry until its ttl elapses") {
+        val time = TestTimeSource()
+        val cache = EnsNameCache(ttl = 5.minutes, timeSource = time)
+        cache.put("vitalik.eth", VITALIK)
+
+        cache.get("vitalik.eth") shouldBe VITALIK
+
+        time += 4.minutes
+        cache.get("vitalik.eth") shouldBe VITALIK
+
+        time += 2.minutes
+        cache.get("vitalik.eth").shouldBeNull()
+    }
+
+    test("clear drops every entry") {
+        val cache = EnsNameCache()
+        cache.put("vitalik.eth", VITALIK)
+
+        cache.clear()
+
+        cache.get("vitalik.eth").shouldBeNull()
+    }
+
+    test("EnsResolver serves a repeated lookup from cache instead of hitting the network again") {
+        val client = FakeJsonRpcClient().enqueueAddressResolution(RESOLVER, VITALIK)
+        val ens = EnsResolver(Provider(client, 1L))
+
+        ens.resolveAddress("vitalik.eth").send().unwrap() shouldBe VITALIK
+        val afterFirst = client.requests.size
+
+        ens.resolveAddress("vitalik.eth").send().unwrap() shouldBe VITALIK
+
+        client.requests.size shouldBe afterFirst
+    }
+})

--- a/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsNameCacheTest.kt
+++ b/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsNameCacheTest.kt
@@ -11,6 +11,7 @@ import kotlin.time.TestTimeSource
 
 private val RESOLVER = Address("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63")
 private val VITALIK = Address("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+private val NICK = Address("0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5")
 
 // TestTimeSource has carried @ExperimentalTime across Kotlin versions and the test tasks only opt into
 // RequiresOptIn/ExperimentalStdlibApi/ExperimentalKotest. Opting in explicitly compiles either way - if the
@@ -29,6 +30,39 @@ class EnsNameCacheTest : FunSpec({
 
         time += 2.minutes
         cache.get("vitalik.eth").shouldBeNull()
+    }
+
+    test("an expired entry is replaced rather than resurrected when it is re-put") {
+        val time = TestTimeSource()
+        val cache = EnsNameCache(ttl = 5.minutes, timeSource = time)
+        cache.put("vitalik.eth", VITALIK)
+
+        time += 6.minutes
+        cache.get("vitalik.eth").shouldBeNull()
+
+        // re-resolving after eviction caches the new value against a fresh mark
+        cache.put("vitalik.eth", NICK)
+        cache.get("vitalik.eth") shouldBe NICK
+
+        time += 4.minutes
+        cache.get("vitalik.eth") shouldBe NICK
+
+        time += 2.minutes
+        cache.get("vitalik.eth").shouldBeNull()
+    }
+
+    test("entries are independent, so evicting one leaves the others intact") {
+        val time = TestTimeSource()
+        val cache = EnsNameCache(ttl = 5.minutes, timeSource = time)
+        cache.put("vitalik.eth", VITALIK)
+
+        time += 3.minutes
+        cache.put("nick.eth", NICK)
+
+        // vitalik.eth expires and is evicted, nick.eth was cached 3 minutes later and still stands
+        time += 3.minutes
+        cache.get("vitalik.eth").shouldBeNull()
+        cache.get("nick.eth") shouldBe NICK
     }
 
     test("clear drops every entry") {

--- a/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsResolverAccountTest.kt
+++ b/ethers-ens/src/commonTest/kotlin/io/ethers/ens/EnsResolverAccountTest.kt
@@ -1,0 +1,60 @@
+package io.ethers.ens
+
+import io.ethers.core.isFailure
+import io.ethers.core.types.Address
+import io.ethers.core.types.BlockId
+import io.ethers.providers.Provider
+import io.github.artificialpb.bignum.bigIntegerOf
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+private val RESOLVER = Address("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63")
+private val VITALIK = Address("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+
+class EnsResolverAccountTest : FunSpec({
+    test("getBalance resolves the name and queries the resolved address") {
+        val client = FakeJsonRpcClient()
+            .enqueueAddressResolution(RESOLVER, VITALIK)
+            .enqueue("eth_getBalance", "\"0x64\"")
+        val ens = EnsResolver(Provider(client, 1L))
+
+        ens.getBalance("vitalik.eth", BlockId.LATEST).send().unwrap() shouldBe bigIntegerOf(100)
+        client.requests.last().params[0] shouldBe VITALIK
+    }
+
+    test("getCode resolves the name and queries the resolved address") {
+        val client = FakeJsonRpcClient()
+            .enqueueAddressResolution(RESOLVER, VITALIK)
+            .enqueue("eth_getCode", "\"0x1234\"")
+        val ens = EnsResolver(Provider(client, 1L))
+
+        ens.getCode("vitalik.eth", BlockId.LATEST).send().isFailure() shouldBe false
+        client.requests.last().params[0] shouldBe VITALIK
+    }
+
+    test("a resolution failure keeps the typed ENS error") {
+        // the registry returns the zero address for the name and for its parent, so the walk up the tree
+        // bottoms out at the empty parent and reports UnknownResolver
+        val client = FakeJsonRpcClient()
+            .enqueue("eth_call", "\"${abiWord(Address.ZERO)}\"")
+            .enqueue("eth_call", "\"${abiWord(Address.ZERO)}\"")
+        val ens = EnsResolver(Provider(client, 1L))
+
+        val result = ens.getBalance("nonexistent.eth", BlockId.LATEST).send()
+
+        result.isFailure() shouldBe true
+        result.unwrapError().shouldBeInstanceOf<EnsResolver.Error.UnknownResolver>()
+    }
+
+    test("an RPC failure after resolution is reported as RpcCallFailed") {
+        // resolution succeeds, but no eth_getBalance response is queued
+        val client = FakeJsonRpcClient().enqueueAddressResolution(RESOLVER, VITALIK)
+        val ens = EnsResolver(Provider(client, 1L))
+
+        val result = ens.getBalance("vitalik.eth", BlockId.LATEST).send()
+
+        result.isFailure() shouldBe true
+        result.unwrapError().shouldBeInstanceOf<EnsResolver.Error.RpcCallFailed>()
+    }
+})

--- a/ethers-ens/src/commonTest/kotlin/io/ethers/ens/FakeJsonRpcClient.kt
+++ b/ethers-ens/src/commonTest/kotlin/io/ethers/ens/FakeJsonRpcClient.kt
@@ -1,0 +1,81 @@
+package io.ethers.ens
+
+import io.channels.core.ChannelReceiver
+import io.ethers.core.Kotlinx
+import io.ethers.core.Result
+import io.ethers.core.failure
+import io.ethers.core.success
+import io.ethers.core.types.Address
+import io.ethers.providers.JsonRpcClient
+import io.ethers.providers.RpcError
+import io.ethers.providers.types.BatchRpcRequest
+import kotlinx.serialization.json.JsonElement as KJsonElement
+
+/**
+ * A [JsonRpcClient] that answers from a queued script instead of the network, and records every request it saw.
+ *
+ * Responses are queued per method and consumed in FIFO order, which is what ENS resolution needs: a single
+ * `resolveAddress` call issues four separate `eth_call` requests that are only distinguishable by their order.
+ * */
+class FakeJsonRpcClient : JsonRpcClient {
+    private val queued = HashMap<String, ArrayDeque<String>>()
+    private val recorded = ArrayList<RecordedRequest>()
+
+    val requests: List<RecordedRequest> get() = recorded
+
+    class RecordedRequest(val method: String, val params: List<Any?>)
+
+    /**
+     * Queue the raw JSON `result` payload returned for the next [method] request.
+     * */
+    fun enqueue(method: String, resultJson: String) = apply {
+        queued.getOrPut(method) { ArrayDeque() }.addLast(resultJson)
+    }
+
+    override suspend fun <T> request(
+        method: String,
+        params: Array<*>,
+        resultDecoder: (KJsonElement) -> T,
+    ): Result<T, RpcError> {
+        recorded.add(RecordedRequest(method, params.toList()))
+
+        val next = queued[method]?.removeFirstOrNull() ?: return failure(
+            RpcError(RpcError.CODE_INTERNAL_ERROR, "FakeJsonRpcClient: no queued response for '$method'"),
+        )
+
+        return success(resultDecoder(Kotlinx.DEFAULT.parseToJsonElement(next)))
+    }
+
+    override suspend fun requestBatch(batch: BatchRpcRequest): Boolean {
+        throw UnsupportedOperationException("FakeJsonRpcClient does not support batching")
+    }
+
+    override suspend fun <T : Any> subscribe(
+        params: Array<*>,
+        resultDecoder: (KJsonElement) -> T,
+    ): Result<ChannelReceiver<T>, RpcError> {
+        return failure(RpcError(RpcError.CODE_METHOD_NOT_FOUND, "FakeJsonRpcClient does not support subscriptions"))
+    }
+
+    override fun close() = Unit
+}
+
+/** ABI-encoded `true`, as returned by `supportsInterface`. */
+const val ABI_TRUE = "0x0000000000000000000000000000000000000000000000000000000000000001"
+
+/** ABI-encoded `false`, as returned by `supportsInterface`. */
+const val ABI_FALSE = "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+/** Left-pad [address] to a full 32-byte ABI word. */
+fun abiWord(address: Address): String = "0x" + "0".repeat(24) + address.toString().removePrefix("0x")
+
+/**
+ * Queue the four `eth_call` responses a non-wildcard [EnsResolver.resolveAddress] performs: registry lookup,
+ * ENSIP-10 support probe, `addr(bytes32)` support probe, and the address itself.
+ * */
+fun FakeJsonRpcClient.enqueueAddressResolution(resolver: Address, resolved: Address) = apply {
+    enqueue("eth_call", "\"${abiWord(resolver)}\"")
+    enqueue("eth_call", "\"$ABI_FALSE\"")
+    enqueue("eth_call", "\"$ABI_TRUE\"")
+    enqueue("eth_call", "\"${abiWord(resolved)}\"")
+}

--- a/ethers-ens/src/commonTest/kotlin/io/ethers/ens/FakeJsonRpcClient.kt
+++ b/ethers-ens/src/commonTest/kotlin/io/ethers/ens/FakeJsonRpcClient.kt
@@ -1,11 +1,13 @@
 package io.ethers.ens
 
 import io.channels.core.ChannelReceiver
+import io.ethers.core.FastHex
 import io.ethers.core.Kotlinx
 import io.ethers.core.Result
 import io.ethers.core.failure
 import io.ethers.core.success
 import io.ethers.core.types.Address
+import io.ethers.core.types.CallRequest
 import io.ethers.providers.JsonRpcClient
 import io.ethers.providers.RpcError
 import io.ethers.providers.types.BatchRpcRequest
@@ -19,6 +21,7 @@ import kotlinx.serialization.json.JsonElement as KJsonElement
  * */
 class FakeJsonRpcClient : JsonRpcClient {
     private val queued = HashMap<String, ArrayDeque<String>>()
+    private val handlers = ArrayList<(String, List<Any?>) -> String?>()
     private val recorded = ArrayList<RecordedRequest>()
 
     val requests: List<RecordedRequest> get() = recorded
@@ -32,12 +35,27 @@ class FakeJsonRpcClient : JsonRpcClient {
         queued.getOrPut(method) { ArrayDeque() }.addLast(resultJson)
     }
 
+    /**
+     * Register a content-based responder, consulted before the [enqueue] queue. Returning null defers to the
+     * next handler, and then to the queue.
+     *
+     * Unlike [enqueue], a handler does not depend on the order requests arrive in, which is what concurrent
+     * resolution needs: several names resolving at once interleave their `eth_call`s arbitrarily.
+     * */
+    fun handle(handler: (method: String, params: List<Any?>) -> String?) = apply { handlers.add(handler) }
+
     override suspend fun <T> request(
         method: String,
         params: Array<*>,
         resultDecoder: (KJsonElement) -> T,
     ): Result<T, RpcError> {
-        recorded.add(RecordedRequest(method, params.toList()))
+        val paramList = params.toList()
+        recorded.add(RecordedRequest(method, paramList))
+
+        val handled = handlers.firstNotNullOfOrNull { it(method, paramList) }
+        if (handled != null) {
+            return success(resultDecoder(Kotlinx.DEFAULT.parseToJsonElement(handled)))
+        }
 
         val next = queued[method]?.removeFirstOrNull() ?: return failure(
             RpcError(RpcError.CODE_INTERNAL_ERROR, "FakeJsonRpcClient: no queued response for '$method'"),
@@ -78,4 +96,43 @@ fun FakeJsonRpcClient.enqueueAddressResolution(resolver: Address, resolved: Addr
     enqueue("eth_call", "\"$ABI_FALSE\"")
     enqueue("eth_call", "\"$ABI_TRUE\"")
     enqueue("eth_call", "\"${abiWord(resolved)}\"")
+}
+
+/** ENSIP-10 (wildcard resolution) interface id, ABI-encoded as the leading bytes of a `bytes4` word. */
+private const val ENSIP_10_INTERFACE_ID = "9061b923"
+
+/**
+ * Serve ENS resolution for [names] by inspecting each `eth_call`'s calldata rather than its arrival order, so
+ * any number of names can resolve concurrently and interleave freely.
+ *
+ * A name that is not in [names] resolves to the zero address in the registry, which is how the real registry
+ * reports "no resolver registered" and makes the name unresolvable.
+ * */
+fun FakeJsonRpcClient.serveEnsNames(resolver: Address, vararg names: Pair<String, Address>) = apply {
+    val byNameHash = names.associate { (name, address) ->
+        FastHex.encodeWithoutPrefix(NameHash.nameHash(name)) to address
+    }
+
+    handle { method, params ->
+        if (method != "eth_call") return@handle null
+
+        val data = (params[0] as? CallRequest)?.data?.toString() ?: return@handle null
+        if (data.length < 74) return@handle null
+
+        val selector = data.substring(0, 10)
+        val firstWord = data.substring(10, 74)
+
+        when (selector) {
+            EnsRegistry.FUNCTION_RESOLVER.selector.toString() ->
+                if (byNameHash.containsKey(firstWord)) "\"${abiWord(resolver)}\"" else "\"${abiWord(Address.ZERO)}\""
+
+            ExtendedResolver.FUNCTION_SUPPORTS_INTERFACE.selector.toString() ->
+                if (firstWord.startsWith(ENSIP_10_INTERFACE_ID)) "\"$ABI_FALSE\"" else "\"$ABI_TRUE\""
+
+            ExtendedResolver.FUNCTION_ADDR.selector.toString() ->
+                byNameHash[firstWord]?.let { "\"${abiWord(it)}\"" }
+
+            else -> null
+        }
+    }
 }

--- a/ethers-ens/src/commonTest/kotlin/io/ethers/ens/FakeJsonRpcClientTest.kt
+++ b/ethers-ens/src/commonTest/kotlin/io/ethers/ens/FakeJsonRpcClientTest.kt
@@ -1,0 +1,47 @@
+package io.ethers.ens
+
+import io.ethers.core.isFailure
+import io.ethers.core.types.Address
+import io.ethers.core.types.BlockId
+import io.ethers.core.types.Bytes
+import io.ethers.core.types.CallRequest
+import io.ethers.providers.Provider
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class FakeJsonRpcClientTest : FunSpec({
+    test("serves queued responses in order and records every request") {
+        val client = FakeJsonRpcClient()
+            .enqueue("eth_call", "\"0xaaaa\"")
+            .enqueue("eth_call", "\"0xbbbb\"")
+        val provider = Provider(client, 1L)
+        val to = Address("0x0000000000000000000000000000000000000001")
+
+        provider.call(CallRequest().to(to), BlockId.LATEST).send().unwrap() shouldBe Bytes("0xaaaa")
+        provider.call(CallRequest().to(to), BlockId.LATEST).send().unwrap() shouldBe Bytes("0xbbbb")
+
+        client.requests.size shouldBe 2
+        client.requests[0].method shouldBe "eth_call"
+        (client.requests[0].params[0] as CallRequest).to shouldBe to
+    }
+
+    test("returns an RpcError when the script is exhausted") {
+        val client = FakeJsonRpcClient()
+        val provider = Provider(client, 1L)
+
+        val result = provider.call(CallRequest(), BlockId.LATEST).send()
+
+        result.isFailure() shouldBe true
+        result.unwrapError().message shouldBe "FakeJsonRpcClient: no queued response for 'eth_call'"
+    }
+
+    test("enqueueAddressResolution drives a full EnsResolver.resolveAddress") {
+        val resolverAddr = Address("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63")
+        val resolved = Address("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+        val client = FakeJsonRpcClient().enqueueAddressResolution(resolverAddr, resolved)
+        val ens = EnsResolver(Provider(client, 1L))
+
+        ens.resolveAddress("vitalik.eth").send().unwrap() shouldBe resolved
+        client.requests.size shouldBe 4
+    }
+})

--- a/ethers-ens/src/jvmSharedTest/kotlin/io/ethers/ens/EnsCallRequestParityTest.kt
+++ b/ethers-ens/src/jvmSharedTest/kotlin/io/ethers/ens/EnsCallRequestParityTest.kt
@@ -1,0 +1,29 @@
+package io.ethers.ens
+
+import io.ethers.core.types.CallRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Signature of every chaining builder on [type]: a non-synthetic, single-argument method that returns the
+ * declaring type itself.
+ */
+private fun buildersOf(type: Class<*>): Set<String> {
+    return type.declaredMethods
+        .filter { !it.isSynthetic && it.returnType == type && it.parameterCount == 1 }
+        .map { "${it.name}(${it.parameterTypes.single().simpleName})" }
+        .toSet()
+}
+
+class EnsCallRequestParityTest : FunSpec({
+    test("EnsCallRequest mirrors every CallRequest chaining builder except to(Address)") {
+        val callRequest = buildersOf(CallRequest::class.java)
+        val ensCallRequest = buildersOf(EnsCallRequest::class.java)
+
+        // to(Address) is intentionally absent: an EnsCallRequest's recipient is always its ENS name
+        (callRequest - ensCallRequest) shouldBe setOf("to(Address)")
+
+        // nothing on EnsCallRequest that CallRequest does not have
+        (ensCallRequest - callRequest) shouldBe emptySet()
+    }
+})

--- a/ethers-ens/src/jvmSharedTest/kotlin/io/ethers/ens/EnsResolverIntegrationTest.kt
+++ b/ethers-ens/src/jvmSharedTest/kotlin/io/ethers/ens/EnsResolverIntegrationTest.kt
@@ -11,7 +11,7 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 // commonTest - it is an integration test, not a unit test, and should not run on every target.
 private const val MAINNET_HTTP_RPC = "https://ethereum-rpc.publicnode.com"
 
-class EnsMiddlewareTest : FunSpec({
+class EnsResolverIntegrationTest : FunSpec({
     data class EnsNameTestData(
         val ensName: String = "",
         val nameHash: String = "",
@@ -23,7 +23,7 @@ class EnsMiddlewareTest : FunSpec({
     )
 
     context("Init provider and resolver") {
-        val ensMiddleware = Provider.builder(MAINNET_HTTP_RPC).build().map(::EnsMiddleware).unwrap()
+        val ensResolver = Provider.builder(MAINNET_HTTP_RPC).build().map(::EnsResolver).unwrap()
 
         context("To address") {
             context("Valid ENS names - No wildcard") {
@@ -46,7 +46,7 @@ class EnsMiddlewareTest : FunSpec({
                         ),
                     ),
                 ) {
-                    ensMiddleware.resolveAddress(it.ensName).send().unwrap() shouldBe it.resolvedAddr
+                    ensResolver.resolveAddress(it.ensName).send().unwrap() shouldBe it.resolvedAddr
                 }
             }
 
@@ -59,7 +59,7 @@ class EnsMiddlewareTest : FunSpec({
                         ),
                     ),
                 ) {
-                    ensMiddleware.resolveAddress(it.ensName).send().unwrap() shouldBe it.resolvedAddr
+                    ensResolver.resolveAddress(it.ensName).send().unwrap() shouldBe it.resolvedAddr
                 }
             }
         }
@@ -75,7 +75,7 @@ class EnsMiddlewareTest : FunSpec({
                         ),
                     ),
                 ) {
-                    ensMiddleware.resolveText(it.ensName, it.key).send().unwrap() shouldBe it.resolvedRecord
+                    ensResolver.resolveText(it.ensName, it.key).send().unwrap() shouldBe it.resolvedRecord
                 }
             }
 
@@ -89,7 +89,7 @@ class EnsMiddlewareTest : FunSpec({
                         ),
                     ),
                 ) {
-                    ensMiddleware.resolveText(it.ensName, it.key).send().unwrap() shouldBe it.resolvedRecord
+                    ensResolver.resolveText(it.ensName, it.key).send().unwrap() shouldBe it.resolvedRecord
                 }
             }
         }
@@ -104,7 +104,7 @@ class EnsMiddlewareTest : FunSpec({
                         ),
                     ),
                 ) {
-                    ensMiddleware.resolveEnsName(it.resolvedAddr).send().unwrap() shouldBe it.ensName
+                    ensResolver.resolveEnsName(it.resolvedAddr).send().unwrap() shouldBe it.ensName
                 }
             }
         }
@@ -136,7 +136,7 @@ class EnsMiddlewareTest : FunSpec({
                         ),
                     ),
                 ) {
-                    ensMiddleware.resolveAvatar(it.ensName).send().unwrap() shouldBe it.resolvedUri
+                    ensResolver.resolveAvatar(it.ensName).send().unwrap() shouldBe it.resolvedUri
                 }
             }
             // TODO uncomment
@@ -150,7 +150,7 @@ class EnsMiddlewareTest : FunSpec({
 //                        ),
 //                    ),
 //                ) {
-//                    ensMiddleware.resolveAvatar(it.resolvedAddr).send().resultOrThrow() shouldBe it.resolvedUri
+//                    ensResolver.resolveAvatar(it.resolvedAddr).send().resultOrThrow() shouldBe it.resolvedUri
 //                }
 //            }
         }
@@ -158,31 +158,31 @@ class EnsMiddlewareTest : FunSpec({
         context("Testing errors") {
             val key = "email"
 
-            // Testing [EnsMiddleware.Error.EnsNameInvalid]
+            // Testing [EnsResolver.Error.EnsNameInvalid]
             test("Invalid ENS names") {
                 listOf("", "\t", ".", "\n.").forEach {
-                    val resolveAddr = ensMiddleware.resolveAddress(it).send()
+                    val resolveAddr = ensResolver.resolveAddress(it).send()
                     resolveAddr.isFailure() shouldBe true
-                    resolveAddr.unwrapError().shouldBeInstanceOf<EnsMiddleware.Error.EnsNameInvalid>()
+                    resolveAddr.unwrapError().shouldBeInstanceOf<EnsResolver.Error.EnsNameInvalid>()
 
-                    val resolveText = ensMiddleware.resolveText(it, key).send()
+                    val resolveText = ensResolver.resolveText(it, key).send()
                     resolveText.isFailure() shouldBe true
-                    resolveText.unwrapError().shouldBeInstanceOf<EnsMiddleware.Error.EnsNameInvalid>()
+                    resolveText.unwrapError().shouldBeInstanceOf<EnsResolver.Error.EnsNameInvalid>()
                 }
             }
 
-            // Testing [EnsMiddleware.Error.Normalisation]
+            // Testing [EnsResolver.Error.Normalisation]
             test("Failed normalisation") {
-                val resolveAddr = ensMiddleware.resolveAddress("xn--u-ccb.com").send()
+                val resolveAddr = ensResolver.resolveAddress("xn--u-ccb.com").send()
                 resolveAddr.isFailure() shouldBe true
-                resolveAddr.unwrapError().shouldBeInstanceOf<EnsMiddleware.Error.Normalisation>()
+                resolveAddr.unwrapError().shouldBeInstanceOf<EnsResolver.Error.Normalisation>()
 
-                val resolveText = ensMiddleware.resolveAddress("xn--u-ccb.com").send()
+                val resolveText = ensResolver.resolveAddress("xn--u-ccb.com").send()
                 resolveText.isFailure() shouldBe true
-                resolveText.unwrapError().shouldBeInstanceOf<EnsMiddleware.Error.Normalisation>()
+                resolveText.unwrapError().shouldBeInstanceOf<EnsResolver.Error.Normalisation>()
             }
 
-            // Testing [EnsMiddleware.Error.UnknownResolver]
+            // Testing [EnsResolver.Error.UnknownResolver]
             context("Resolver not found") {
                 withData(
                     listOf(
@@ -191,21 +191,21 @@ class EnsMiddlewareTest : FunSpec({
                         ),
                     ),
                 ) {
-                    val resolveAddr = ensMiddleware.resolveAddress(it.ensName).send()
+                    val resolveAddr = ensResolver.resolveAddress(it.ensName).send()
                     resolveAddr.isFailure() shouldBe true
-                    resolveAddr.unwrapError().shouldBeInstanceOf<EnsMiddleware.Error.UnknownResolver>()
+                    resolveAddr.unwrapError().shouldBeInstanceOf<EnsResolver.Error.UnknownResolver>()
 
-                    val resolveText = ensMiddleware.resolveText(it.ensName, key).send()
+                    val resolveText = ensResolver.resolveText(it.ensName, key).send()
                     resolveText.isFailure() shouldBe true
-                    resolveText.unwrapError().shouldBeInstanceOf<EnsMiddleware.Error.UnknownResolver>()
+                    resolveText.unwrapError().shouldBeInstanceOf<EnsResolver.Error.UnknownResolver>()
 
-                    val resolveEns = ensMiddleware.resolveEnsName(Address.ZERO).send()
+                    val resolveEns = ensResolver.resolveEnsName(Address.ZERO).send()
                     resolveEns.isFailure() shouldBe true
-                    resolveEns.unwrapError().shouldBeInstanceOf<EnsMiddleware.Error.EnsNameInvalid>()
+                    resolveEns.unwrapError().shouldBeInstanceOf<EnsResolver.Error.EnsNameInvalid>()
                 }
             }
 
-            // Testing [EnsMiddleware.Error.UnsupportedSelector]
+            // Testing [EnsResolver.Error.UnsupportedSelector]
             context("Unsupported selector") {
                 withData(
                     listOf(
@@ -217,13 +217,13 @@ class EnsMiddlewareTest : FunSpec({
                     // TODO: tests for other resolutions when mocking
                     // address with invalid resolver (WETH token 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 as resolver)
                     val addr = Address("0x30c9223d9e3d23e0af1073a38e0834b055bf68ed")
-                    val resolveEns = ensMiddleware.resolveEnsName(addr).send()
+                    val resolveEns = ensResolver.resolveEnsName(addr).send()
                     resolveEns.isFailure() shouldBe true
-                    resolveEns.unwrapError().shouldBeInstanceOf<EnsMiddleware.Error.UnsupportedSelector>()
+                    resolveEns.unwrapError().shouldBeInstanceOf<EnsResolver.Error.UnsupportedSelector>()
                 }
             }
 
-            // Testing [EnsMiddleware.Error.IncorrectOwner]
+            // Testing [EnsResolver.Error.IncorrectOwner]
             context("Incorrect owner") {
                 /*context("Avatars - is not NFT owner") {
                     withData(
@@ -235,9 +235,9 @@ class EnsMiddlewareTest : FunSpec({
                             ),
                         ),
                     ) {
-                        val resolveAvatar = ensMiddleware.resolveAvatar(it.ensName).send()
+                        val resolveAvatar = ensResolver.resolveAvatar(it.ensName).send()
                         resolveAvatar.isFailure() shouldBe true
-                        resolveAvatar.unwrapError().shouldBeInstanceOf<EnsMiddleware.Error.IncorrectOwner>()
+                        resolveAvatar.unwrapError().shouldBeInstanceOf<EnsResolver.Error.IncorrectOwner>()
                     }
                 }*/
 
@@ -256,22 +256,22 @@ class EnsMiddlewareTest : FunSpec({
                         ),
                     ),
                 ) {
-                    val resolveAddress = ensMiddleware.resolveAddress(it.ensName).send()
+                    val resolveAddress = ensResolver.resolveAddress(it.ensName).send()
                     resolveAddress.isFailure() shouldBe true
                     val error = resolveAddress.unwrapError()
-                    error.shouldBeInstanceOf<EnsMiddleware.Error.UnknownEnsName>()
+                    error.shouldBeInstanceOf<EnsResolver.Error.UnknownEnsName>()
                     error.resolverAddr shouldBe it.resolverAddr
                     error.nameHash shouldBe it.nameHash
 
-                    ensMiddleware.resolveText(it.ensName, "").send().unwrap() shouldBe ""
+                    ensResolver.resolveText(it.ensName, "").send().unwrap() shouldBe ""
                 }
             }
 
-            // Testing [EnsMiddleware.Error.UnsupportedScheme]
+            // Testing [EnsResolver.Error.UnsupportedScheme]
             // TODO: when mocking
             context("Avatars - UnsupportedScheme")
 
-            // Testing [EnsMiddleware.Error.AvatarParsing]
+            // Testing [EnsResolver.Error.AvatarParsing]
             // TODO: when mocking
             context("Avatars - AvatarParsing")
         }


### PR DESCRIPTION
## Description

`EnsMiddleware` implemented `Middleware by provider` but overrode no `Middleware` method. It was purely additive — it delegated the whole interface and bolted on `resolveAddress`/`resolveText`/`resolveEnsName`/`resolveAvatar`, none of which are part of that interface. Anything accepting a `Middleware` gained nothing from being handed one.

It also misreported its position in the chain: class delegation forwards `inner` too, so `EnsMiddleware(provider).inner` returned `provider.inner` — `null` for a `Provider`. It claimed to be the bottom-most layer while actually being a wrapper, so nothing stacked above it could see it.

Separately, there was no way to pass an ENS name where an `Address` is expected — the thing a middleware layer is actually good for.

## Solution

Split the type in two, so each is honest about what it is.

**`EnsResolver`** — the former `EnsMiddleware`, now holding the provider by composition instead of delegating `Middleware`. Keeps the typed `EnsResolver.Error` API. Also gains ENS-name overloads for `getBalance` / `getCode` / `getTransactionCount` / `getStorage`, which take a bare `Address` and therefore cannot be intercepted.

**`EnsMiddleware`** — a real `Middleware` layer that earns the name. It accepts an `EnsCallRequest` anywhere a call request is expected, resolves the name, and forwards a plain `CallRequest` to `inner`. Supported on `call`, `estimateGas`, `createAccessList`, `fillTransaction`, `traceCall`, `callMany` and `traceCallMany`. Non-ENS requests pass through untouched, at no extra cost.

**`EnsCallRequest`** carries the unresolved name. `IntoCallRequest.toCallRequest()` is synchronous and infallible, so it cannot resolve lazily — instead it throws, naming the fix, rather than silently sending a call with no recipient. It mirrors every `CallRequest` chaining builder except `to(Address)` (which would give it two competing recipients), plus a builder-lambda overload and a `CallRequest.toEns(name)` extension.

**`EnsNameCache`** — 5-minute TTL, since interception turns one `eth_call` into five round trips and ENS records change rarely.

### Two things reviewers should know

**Kotlin class delegation generates a forwarder to `inner` for every interface member not explicitly overridden — including members with a default body.** `EthApi.call(call, blockId)` has the default body `= call(call, blockId, null, null)`, so its generated forwarder calls `inner.call(...)`, which dispatches to `inner`'s own 4-arg `call`. Overriding only the abstract method is not enough; every convenience overload has to be overridden too. This was verified by deleting one override and watching the corresponding test fail. It is also a latent trap in the `GasOracleMiddleware` example in `Middleware.kt`'s KDoc — `getGasPrice()` has no overloads, so it happens not to bite there.

**Batch methods resolve names concurrently, and one unresolvable name fails the whole batch.** A batch exists to save round trips; resolving N names sequentially in front of it would cost more than it saves. Whole-batch failure rather than a per-entry failure because `CallFailedError` carries only a `String` — a per-entry failure would be indistinguishable from a revert, and an unresolvable name is bad input rather than an execution result.

### Breaking change

`EnsMiddleware` → `EnsResolver`, which no longer implements `Middleware`. Replace `EnsMiddleware(provider)` with `EnsResolver(provider)` and call the provider directly for RPC methods.

There is deliberately **no deprecated alias**: the name `EnsMiddleware` is immediately reused by the new interception layer, so an alias and the new class cannot coexist.

### Tests

54 tests in `ethers-ens`, all network-free except the existing integration suite. `FakeJsonRpcClient` is a new scripted `JsonRpcClient`; it grew content-based responders because its FIFO-per-method queue assumes sequential consumption, which concurrent resolution breaks. `EnsCallRequestParityTest` reflects over both types and fails the build if `CallRequest` gains a chaining builder that `EnsCallRequest` does not mirror.

The concurrency test was verified non-vacuous by making resolution sequential and confirming it — and only it — fails.

Full suite green across JVM, macosArm64 and iosSimulatorArm64, plus `ktlintFormat check`.

CHANGELOG is intentionally untouched, since it is generated from conventional commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PJQUu9suLxjzAFz94fGKz
